### PR TITLE
Migrate gtk use to GTK4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ feature_gtk = ["gdk", "gdkx11", "gtk"]
 
 [dependencies]
 enumflags2 = "0.6"
-gdk = {version = "0.13", optional = true}
-gtk = { version = "0.9", optional = true}
-gdkx11 = {version = "0.9", optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_repr = "0.1"
 strum = "0.19"
@@ -25,3 +22,18 @@ strum_macros = "0.19"
 zbus = {version = "1.1"}
 zvariant = {version = "2.2", features = ["enumflags2"]}
 zvariant_derive = {version = "2.2"}
+
+[dependencies.gdk]
+package = "gdk4"
+optional = true
+git = "https://github.com/gtk-rs/gtk4-rs.git"
+
+[dependencies.gtk]
+package = "gtk4"
+optional = true
+git = "https://github.com/gtk-rs/gtk4-rs.git"
+
+[dependencies.gdkx11]
+package = "gdk4-x11"
+optional = true
+git = "https://github.com/gtk-rs/gtk4-rs.git"


### PR DESCRIPTION
Use GTK4 APIs for the window identifier.