### PR TITLE
bump to new zbus

### DIFF
--- a/.github/workflows/demo-ci.yml
+++ b/.github/workflows/demo-ci.yml
@@ -12,7 +12,7 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v2
-      - uses: bilelmoussaoui/flatpak-github-actions@master
+      - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
         with:
           bundle: "ashpd-demo.flatpak"
           manifest-path: "ashpd-demo/build-aux/com.belmoussaoui.ashpd.demo.Devel.json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ serde_repr = "0.1"
 strum = "0.20"
 strum_macros = "0.20"
 zbus = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main"}
-zvariant = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main", features = ["enumflags2"]}
+zvariant = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main", features = ["enumflags2"], default-features = false}
 zvariant_derive = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main"}
 
 futures = "0.3"
-futures-lite = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ zvariant = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main", f
 zvariant_derive = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main"}
 
 futures = "0.3"
+futures-lite = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ gtk4 = {git = "https://github.com/gtk-rs/gtk4-rs", optional = true}
 
 serde = {version = "1.0", features = ["derive"]}
 serde_repr = "0.1"
+rand = "0.8"
 strum = "0.20"
 strum_macros = "0.20"
 zbus = {git = "https://gitlab.freedesktop.org/dbus/zbus", branch = "main"}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ pub async fn run() -> Result<(), ashpd::Error> {
 | Feature | Description |
 | ---     | ----------- |
 | feature_gtk3 | Implement `From<Color>` for `gdk3::RGBA` |
-|  | Implement `From<gtk3::Window>` for `WindowIdentifier` |
+|  | Provides `WindowIdentifier::from_window` |
 | feature_gtk4 | Implement `From<Color>` for `gdk4::RGBA` |
 |  | Provides `WindowIdentifier::from_window` |

--- a/README.md
+++ b/README.md
@@ -12,18 +12,13 @@ It provides an alternative to the C library [https://github.com/flatpak/libporta
 Ask the compositor to pick a color
 
 ```rust,no_run
-use ashpd::{
-    desktop::screenshot::{PickColorOptions, ScreenshotProxy},
-    WindowIdentifier,
-};
+use ashpd::desktop::screenshot::ScreenshotProxy;
 
 async fn run() -> Result<(), ashpd::Error> {
-    let identifier = WindowIdentifier::default();
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = ScreenshotProxy::new(&connection).await?;
-    let color = proxy
-        .pick_color(identifier, PickColorOptions::default())
-        .await?;
+
+    let color = proxy.pick_color(Default::default).await?;
     println!("({}, {}, {})", color.red(), color.green(), color.blue());
     Ok(())
 }
@@ -32,15 +27,15 @@ async fn run() -> Result<(), ashpd::Error> {
 Start a PipeWire stream from the user's camera
 
 ```rust,no_run
-use std::collections::HashMap;
-use ashpd::desktop::camera::{CameraAccessOptions, CameraProxy};
+use ashpd::desktop::camera::CameraProxy;
 
 pub async fn run() -> Result<(), ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = CameraProxy::new(&connection).await?;
+
     if proxy.is_camera_present().await? {
-        proxy.access_camera(CameraAccessOptions::default()).await?;
-        let remote_fd = proxy.open_pipe_wire_remote(HashMap::new()).await?;
+        proxy.access_camera().await?;
+        let remote_fd = proxy.open_pipe_wire_remote().await?;
         // pass the remote fd to GStreamer for example
     }
     Ok(())

--- a/ashpd-demo/Cargo.lock
+++ b/ashpd-demo/Cargo.lock
@@ -20,14 +20,14 @@ checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 [[package]]
 name = "ashpd"
 version = "0.1.0"
-source = "git+https://github.com/bilelmoussaoui/ashpd?branch=bilelmoussaoui/bump-to-new-zbus#5a45954a2127522596feac4b5b78f90a5f1ff381"
+source = "git+https://github.com/bilelmoussaoui/ashpd?branch=bilelmoussaoui/bump-to-new-zbus#27726e92c8b7dfb16d1c9d7910abde27b2643b0f"
 dependencies = [
  "enumflags2",
  "futures",
- "futures-lite",
  "gdk4-wayland",
  "gdk4-x11",
  "gtk4",
+ "rand",
  "serde",
  "serde_repr",
  "strum",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "gstreamer"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a94d84e7805196364b4fc584205ce4882f3acd81"
 dependencies = [
  "glib-sys",
  "gobject-sys",

--- a/ashpd-demo/Cargo.lock
+++ b/ashpd-demo/Cargo.lock
@@ -4,26 +4,27 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "ashpd"
 version = "0.1.0"
-source = "git+https://github.com/bilelmoussaoui/ashpd#0b3bfbbe34ef65a853663953cc7bd38b59fa0473"
+source = "git+https://github.com/bilelmoussaoui/ashpd?branch=bilelmoussaoui/bump-to-new-zbus#5a45954a2127522596feac4b5b78f90a5f1ff381"
 dependencies = [
  "enumflags2",
  "futures",
+ "futures-lite",
  "gdk4-wayland",
  "gdk4-x11",
  "gtk4",
@@ -55,33 +56,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "1.3.1"
+name = "async-broadcast"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "8c53006e3a562799d414fad784fdb8789dcf94f78f9e66e642347e50492852f7"
+dependencies = [
+ "easy-parallel",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
- "vec-arena",
+ "slab",
+ "socket2",
  "waker-fn",
  "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "atty"
@@ -126,8 +169,8 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cairo-rs"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
@@ -138,8 +181,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib-sys",
  "libc",
@@ -148,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-expr"
@@ -203,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "easy-parallel"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd4afd79212583ff429b913ad6605242ed7eec277e950b1438f300748f948f4"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,18 +299,18 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "field-offset"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf539fba70056b50f40a22e0da30639518a12ee18c35807858a63b158cb6dde7"
+checksum = "1e1c54951450cbd39f3dbcf1005ac413b49487dabf18a720ad2383eccfeffb92"
 dependencies = [
  "memoffset",
  "rustc_version",
@@ -269,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -284,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -294,15 +343,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -311,15 +360,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -332,10 +381,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -344,22 +394,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -376,8 +427,8 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -387,8 +438,8 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -400,7 +451,7 @@ dependencies = [
 [[package]]
 name = "gdk4"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -415,13 +466,14 @@ dependencies = [
 [[package]]
 name = "gdk4-sys"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gio-sys",
  "glib-sys",
  "gobject-sys",
+ "graphene-sys",
  "libc",
  "pango-sys",
  "system-deps",
@@ -430,7 +482,7 @@ dependencies = [
 [[package]]
 name = "gdk4-wayland"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "gdk4",
  "gdk4-wayland-sys",
@@ -443,7 +495,7 @@ dependencies = [
 [[package]]
 name = "gdk4-wayland-sys"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "glib-sys",
  "libc",
@@ -453,7 +505,7 @@ dependencies = [
 [[package]]
 name = "gdk4-x11"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "gdk4",
  "gdk4-x11-sys",
@@ -466,7 +518,7 @@ dependencies = [
 [[package]]
 name = "gdk4-x11-sys"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "gdk4-sys",
  "glib-sys",
@@ -477,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -488,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4e7a9dc238dddd30f183d43e4f497990885daa211fcf01657159ade8f1610"
+checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -508,8 +560,8 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -524,8 +576,8 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -536,8 +588,8 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -554,8 +606,8 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "anyhow",
  "heck",
@@ -568,8 +620,8 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "libc",
  "system-deps",
@@ -577,8 +629,8 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib-sys",
  "libc",
@@ -587,8 +639,8 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -597,8 +649,8 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib-sys",
  "libc",
@@ -609,7 +661,7 @@ dependencies = [
 [[package]]
 name = "gsk4"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -624,7 +676,7 @@ dependencies = [
 [[package]]
 name = "gsk4-sys"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -639,7 +691,7 @@ dependencies = [
 [[package]]
 name = "gstreamer"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -661,7 +713,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -674,7 +726,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -686,7 +738,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -697,7 +749,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -713,7 +765,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video-sys"
 version = "0.17.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#8da8e31d63f0022b8d95ac716b1aa630140e6640"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#6a5f17ae065d55bda64f3f749e43fd9b8b5be9d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -725,14 +777,14 @@ dependencies = [
 
 [[package]]
 name = "gtk-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1874c48e670519ce192093ac906c08a6dde7cb2d18b28722ef237726a39c3a63"
+checksum = "da5bf7748fd4cd0b2490df8debcc911809dbcbee4ece9531b96c29a9c729de5a"
 
 [[package]]
 name = "gtk4"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -754,11 +806,11 @@ dependencies = [
 [[package]]
 name = "gtk4-macros"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "anyhow",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
@@ -769,7 +821,7 @@ dependencies = [
 [[package]]
 name = "gtk4-sys"
 version = "0.1.0"
-source = "git+https://github.com/gtk-rs/gtk4-rs#05269f0cc6b7d31c69464cd58485509e20f1ca7e"
+source = "git+https://github.com/gtk-rs/gtk4-rs#5db703baab049ee46ddaaaa388a0c768105accce"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -786,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -828,18 +880,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -853,15 +896,13 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "libadwaita"
 version = "0.1.0"
-source = "git+https://gitlab.gnome.org/bilelmoussaoui/libadwaita-rs#6ae4d3670565064acc9da2f51434eca0a0c51ac9"
+source = "git+https://gitlab.gnome.org/World/Rust/libadwaita-rs#386d6bb5aae3c171acbc098903d42066a6b33f28"
 dependencies = [
- "bitflags",
  "gdk-pixbuf",
  "gdk4",
  "gio",
  "glib",
  "gtk4",
- "lazy_static",
  "libadwaita-sys",
  "libc",
  "pango",
@@ -870,7 +911,7 @@ dependencies = [
 [[package]]
 name = "libadwaita-sys"
 version = "0.1.0"
-source = "git+https://gitlab.gnome.org/bilelmoussaoui/libadwaita-rs#6ae4d3670565064acc9da2f51434eca0a0c51ac9"
+source = "git+https://gitlab.gnome.org/World/Rust/libadwaita-rs#386d6bb5aae3c171acbc098903d42066a6b33f28"
 dependencies = [
  "gdk-pixbuf-sys",
  "gdk4-sys",
@@ -885,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -932,15 +973,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -952,16 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5136edda114182728ccdedb9f5eda882781f35fa6e80cc360af12a8932507f3"
 
 [[package]]
-name = "nb-connect"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
-dependencies = [
- "libc",
- "socket2",
-]
-
-[[package]]
 name = "nix"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1002,19 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1034,14 +1078,14 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "pango"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "bitflags",
  "glib",
@@ -1052,8 +1096,8 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.13.0"
-source = "git+https://github.com/gtk-rs/gtk-rs#bcaa62884113e86d6b6c285d7c13f85f0ab124ab"
+version = "0.14.0"
+source = "git+https://github.com/gtk-rs/gtk-rs-core#341512a140b6ac0dd5fc30683296305e80059815"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1102,14 +1146,14 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
 dependencies = [
  "cfg-if",
  "libc",
  "log",
- "wepoll-sys",
+ "wepoll-ffi",
  "winapi",
 ]
 
@@ -1137,10 +1181,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
 dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -1182,9 +1227,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1206,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1218,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1228,36 +1273,36 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1266,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1314,18 +1359,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1334,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1351,9 +1396,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "slotmap"
@@ -1381,6 +1426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strum"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1418,7 +1469,7 @@ dependencies = [
  "anyhow",
  "cfg-expr",
  "heck",
- "itertools 0.10.0",
+ "itertools",
  "pkg-config",
  "strum",
  "strum_macros",
@@ -1452,18 +1503,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1493,15 +1544,9 @@ checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "vec-arena"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b2f665b594b07095e3ac3f718e13c2197143416fae4c5706cffb7b1af8d7f1"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version-compare"
@@ -1536,7 +1581,7 @@ dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix",
+ "nix 0.20.0",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -1549,7 +1594,7 @@ version = "0.28.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd75ae380325dbcff2707f0cd9869827ea1d2d6d534cff076858d3f0460fd5a"
 dependencies = [
- "nix",
+ "nix 0.20.0",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -1577,10 +1622,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys"
-version = "3.0.1"
+name = "wepoll-ffi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
 ]
@@ -1634,20 +1679,23 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "zbus"
-version = "2.0.0-beta.3"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#1fdc94c281143a9d57a356e90accda20ca28ca9a"
+version = "2.0.0-beta.5"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#b2cf3b0cf2785c6bd5d26ad4c6c43b7f3e395234"
 dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-executor",
  "async-io",
  "async-lock",
+ "async-task",
  "byteorder",
  "derivative",
  "enumflags2",
- "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.21.0",
  "once_cell",
  "rand",
  "scoped-tls",
@@ -1655,36 +1703,39 @@ dependencies = [
  "serde_repr",
  "sha1",
  "slotmap",
+ "static_assertions",
  "zbus_macros",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "2.0.0-beta.3"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#1fdc94c281143a9d57a356e90accda20ca28ca9a"
+version = "2.0.0-beta.5"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#b2cf3b0cf2785c6bd5d26ad4c6c43b7f3e395234"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "regex",
  "syn",
 ]
 
 [[package]]
 name = "zvariant"
-version = "2.6.0"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#1fdc94c281143a9d57a356e90accda20ca28ca9a"
+version = "2.7.0"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#b2cf3b0cf2785c6bd5d26ad4c6c43b7f3e395234"
 dependencies = [
  "byteorder",
  "enumflags2",
  "serde",
+ "static_assertions",
  "zvariant_derive",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "2.6.0"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#1fdc94c281143a9d57a356e90accda20ca28ca9a"
+version = "2.7.0"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?branch=main#b2cf3b0cf2785c6bd5d26ad4c6c43b7f3e395234"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/ashpd-demo/Cargo.toml
+++ b/ashpd-demo/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 pretty_env_logger = "0.4"
-gettext-rs = { version = "0.6", features = ["gettext-system"] }
-gtk-macros = "0.2"
+gettext-rs = { version = "0.7", features = ["gettext-system"] }
+gtk-macros = "0.3"
 once_cell = "1.5"
 futures = "0.3"
 gst_video = {package="gstreamer-video", git="https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"}
@@ -22,8 +22,9 @@ git = "https://github.com/gtk-rs/gtk4-rs"
 
 [dependencies.ashpd]
 git = "https://github.com/bilelmoussaoui/ashpd"
+branch = "bilelmoussaoui/bump-to-new-zbus"
 features = ["feature_gtk4"]
 
 [dependencies.adw]
 package = "libadwaita"
-git = "https://gitlab.gnome.org/bilelmoussaoui/libadwaita-rs"
+git = "https://gitlab.gnome.org/World/Rust/libadwaita-rs"

--- a/ashpd-demo/build-aux/com.belmoussaoui.ashpd.demo.Devel.json
+++ b/ashpd-demo/build-aux/com.belmoussaoui.ashpd.demo.Devel.json
@@ -30,21 +30,44 @@
     },
     "modules": [
         {
-            "name": "libadwaita",
-            "buildsystem": "meson",
+            "name" : "libadwaita",
+            "buildsystem" : "meson",
             "config-opts": [
                 "-Dintrospection=disabled",
                 "-Dgtk_doc=false",
                 "-Dtests=false",
                 "-Dexamples=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
+                "-Dvapi=false"
             ],
-            "sources": [
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "sources" : [{
+                "type": "git",
+                "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                "tag": "1.0.0-alpha.1"
+            }],
+            "modules": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/exalm/libadwaita.git",
-                    "branch": "main"
+                    "name" : "libsass",
+                    "buildsystem" : "meson",
+                    "cleanup": ["*"],
+                    "sources" : [{
+                        "type" : "git",
+                        "url" : "https://github.com/lazka/libsass.git",
+                        "branch" : "meson"
+                    }]
+                },
+                {
+                    "name" : "sassc",
+                    "buildsystem" : "meson",
+                    "cleanup": ["*"],
+                    "sources" : [{
+                        "type" : "git",
+                        "url" : "https://github.com/lazka/sassc.git",
+                        "branch" : "meson"
+                    }]
                 }
             ]
         },

--- a/ashpd-demo/data/resources.gresource.xml
+++ b/ashpd-demo/data/resources.gresource.xml
@@ -9,6 +9,7 @@
         <file compressed="true" preprocess="xml-stripblanks" alias="background.ui">resources/ui/background.ui</file>
         <file compressed="true" preprocess="xml-stripblanks" alias="camera.ui">resources/ui/camera.ui</file>
         <file compressed="true" preprocess="xml-stripblanks" alias="device.ui">resources/ui/device.ui</file>
+        <file compressed="true" preprocess="xml-stripblanks" alias="documents.ui">resources/ui/documents.ui</file>
         <file compressed="true" preprocess="xml-stripblanks" alias="email.ui">resources/ui/email.ui</file>
         <file compressed="true" preprocess="xml-stripblanks" alias="location.ui">resources/ui/location.ui</file>
         <file compressed="true" preprocess="xml-stripblanks" alias="network_monitor.ui">resources/ui/network_monitor.ui</file>

--- a/ashpd-demo/data/resources/ui/documents.ui
+++ b/ashpd-demo/data/resources/ui/documents.ui
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="DocumentsPage" parent="AdwBin">
+    <child>
+      <object class="GtkBox">
+        <property name="hexpand">True</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="title">Information</property>
+            <child>
+              <object class="GtkListBox">
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="AdwActionRow">
+                    <property name="title">Mount point</property>
+                    <child>
+                      <object class="GtkLabel" id="mount_point">
+                        <property name="label">Undefined</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <style>
+                  <class name="content"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/ashpd-demo/data/resources/ui/window.ui
+++ b/ashpd-demo/data/resources/ui/window.ui
@@ -119,6 +119,12 @@
                         <property name="page-name">wallpaper</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="SidebarRow">
+                        <property name="label">Documents</property>
+                        <property name="page-name">documents</property>
+                      </object>
+                    </child>
                     <style>
                       <class name="navigation-sidebar"/>
                     </style>
@@ -297,6 +303,14 @@
                             <property name="name">wallpaper</property>
                             <property name="child">
                               <object class="WallpaperPage" id="wallpaper" />
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="name">documents</property>
+                            <property name="child">
+                              <object class="DocumentsPage" id="documents" />
                             </property>
                           </object>
                         </child>

--- a/ashpd-demo/src/application.rs
+++ b/ashpd-demo/src/application.rs
@@ -47,7 +47,7 @@ mod imp {
             app.setup_gactions();
             app.setup_accels();
 
-            app.get_main_window().present();
+            app.main_window().present();
         }
 
         fn startup(&self, app: &Self::Type) {
@@ -58,11 +58,11 @@ mod imp {
             provider.load_from_resource("/com/belmoussaoui/ashpd/demo/style.css");
             app.set_resource_base_path(Some("/com/belmoussaoui/ashpd/demo/"));
 
-            if let Some(ref display) = gtk::gdk::Display::get_default() {
-                let theme = gtk::IconTheme::get_for_display(display).unwrap();
+            if let Some(ref display) = gtk::gdk::Display::default() {
+                let theme = gtk::IconTheme::for_display(display).unwrap();
                 theme.add_resource_path("/com/belmoussaoui/ashpd/demo/icons/");
                 gtk::StyleContext::add_provider_for_display(
-                    &display,
+                    display,
                     &provider,
                     gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
                 );
@@ -87,7 +87,7 @@ impl ExampleApplication {
         .expect("Application initialization failed...")
     }
 
-    fn get_main_window(&self) -> ExampleApplicationWindow {
+    fn main_window(&self) -> ExampleApplicationWindow {
         let priv_ = imp::ExampleApplication::from_instance(self);
         priv_.window.get().unwrap().upgrade().unwrap()
     }
@@ -100,7 +100,7 @@ impl ExampleApplication {
             clone!(@weak self as app => move |_, _| {
                 // This is needed to trigger the delete event
                 // and saving the window state
-                app.get_main_window().close();
+                app.main_window().close();
                 app.quit();
             })
         );
@@ -128,7 +128,7 @@ impl ExampleApplication {
             .license_type(gtk::License::MitX11)
             .website("https://github.com/bilelmoussaoui/ashpd/")
             .version(config::VERSION)
-            .transient_for(&self.get_main_window())
+            .transient_for(&self.main_window())
             .modal(true)
             .authors(vec!["Bilal Elmoussaoui".into()])
             .artists(vec!["Bilal Elmoussaoui".into()])

--- a/ashpd-demo/src/meson.build
+++ b/ashpd-demo/src/meson.build
@@ -32,6 +32,8 @@ sources = files(
   'portals/desktop/screenshot.rs',
   'portals/desktop/screencast.rs',
   'portals/desktop/wallpaper.rs',
+  'portals/documents.rs',
+  'portals/mod.rs',
   'widgets/color_widget.rs',
   'widgets/gst_paintable.rs',
   'widgets/mod.rs',

--- a/ashpd-demo/src/portals/desktop/account.rs
+++ b/ashpd-demo/src/portals/desktop/account.rs
@@ -70,9 +70,9 @@ impl AccountPage {
 
             if let Ok(user_info) = user_information(identifier, &reason).await
             {
-                self_.id_label.set_text(&user_info.id);
-                self_.name_label.set_text(&user_info.name);
-                let file = gio::File::for_uri(&user_info.image);
+                self_.id_label.set_text(user_info.id());
+                self_.name_label.set_text(user_info.name());
+                let file = gio::File::for_uri(user_info.image());
                 let icon = gio::FileIcon::new(&file);
                 self_.avatar.set_from_gicon(&icon);
                 self_.response_group.show();
@@ -87,8 +87,6 @@ async fn user_information(
 ) -> Result<account::UserInfo, ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = account::AccountProxy::new(&connection).await?;
-    let info = proxy
-        .user_information(window, account::UserInfoOptions::default().reason(reason))
-        .await?;
+    let info = proxy.user_information(window, reason).await?;
     Ok(info)
 }

--- a/ashpd-demo/src/portals/desktop/camera.rs
+++ b/ashpd-demo/src/portals/desktop/camera.rs
@@ -1,13 +1,9 @@
-use std::{
-    collections::HashMap,
-    os::unix::prelude::{AsRawFd, RawFd},
-};
-
 use ashpd::{desktop::camera, zbus};
 use glib::clone;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
+use std::os::unix::prelude::{AsRawFd, RawFd};
 
 use crate::widgets::CameraPaintable;
 
@@ -132,10 +128,8 @@ impl CameraPage {
 async fn stream() -> Result<RawFd, ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = camera::CameraProxy::new(&connection).await?;
-    proxy
-        .access_camera(camera::CameraAccessOptions::default())
-        .await?;
+    proxy.access_camera().await?;
 
-    let fd = proxy.open_pipe_wire_remote(HashMap::new()).await?;
+    let fd = proxy.open_pipe_wire_remote().await?;
     Ok(fd.as_raw_fd())
 }

--- a/ashpd-demo/src/portals/desktop/email.rs
+++ b/ashpd-demo/src/portals/desktop/email.rs
@@ -1,4 +1,4 @@
-use ashpd::desktop::email::{EmailOptions, EmailProxy};
+use ashpd::desktop::email::{Email, EmailProxy};
 use ashpd::{zbus, WindowIdentifier};
 use gtk::glib;
 use gtk::prelude::*;
@@ -67,9 +67,9 @@ impl EmailPage {
         let ctx = glib::MainContext::default();
         ctx.spawn_local(async move {
             let identifier = WindowIdentifier::from_window(&root).await;
-            if let Ok(email) = compose_email(
+            let _ = compose_email(
                 identifier,
-                EmailOptions::default()
+                Email::default()
                     .subject(&subject)
                     .addresses(
                         &addresses
@@ -81,18 +81,14 @@ impl EmailPage {
                     .cc(&cc.split(",").filter(|e| e.len() > 1).collect::<Vec<_>>())
                     .body(&body),
             )
-            .await
-            {
-                //TODO: handle the response
-                println!("{:#?}", email);
-            }
+            .await;
         });
     }
 }
 
 pub async fn compose_email(
     window_identifier: WindowIdentifier,
-    email: EmailOptions,
+    email: Email,
 ) -> Result<(), ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = EmailProxy::new(&connection).await?;

--- a/ashpd-demo/src/portals/desktop/location.rs
+++ b/ashpd-demo/src/portals/desktop/location.rs
@@ -1,16 +1,12 @@
 use adw::prelude::*;
-use ashpd::zbus;
 use ashpd::{
-    desktop::location::{
-        Accuracy, CreateSessionOptions, Location, LocationProxy, SessionStartOptions,
-    },
-    HandleToken, WindowIdentifier,
+    desktop::location::{Accuracy, Location, LocationProxy},
+    zbus, WindowIdentifier,
 };
 use glib::clone;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use std::convert::TryFrom;
 
 mod imp {
     use adw::subclass::prelude::*;
@@ -128,17 +124,13 @@ pub async fn locate(
     let proxy = LocationProxy::new(&connection).await?;
     let session = proxy
         .create_session(
-            CreateSessionOptions::default()
-                .session_handle_token(HandleToken::try_from("sometokenstuff").unwrap())
-                .distance_threshold(distance_threshold)
-                .time_threshold(time_threshold)
-                .accuracy(accuracy),
+            Some(distance_threshold),
+            Some(time_threshold),
+            Some(accuracy),
         )
         .await?;
 
-    proxy
-        .start(&session, window_identifier, SessionStartOptions::default())
-        .await?;
+    proxy.start(&session, window_identifier).await?;
     let location = proxy.receive_location_updated().await?;
 
     session.close().await?;

--- a/ashpd-demo/src/portals/desktop/network_monitor.rs
+++ b/ashpd-demo/src/portals/desktop/network_monitor.rs
@@ -56,6 +56,7 @@ mod imp {
     }
     impl ObjectImpl for NetworkMonitorPage {
         fn constructed(&self, obj: &Self::Type) {
+            /*
             let proxy = NetworkMonitorProxy::new(&self.connection).unwrap();
             obj.set_sensitive(!ashpd::is_sandboxed());
 
@@ -68,6 +69,7 @@ mod imp {
                 self.connectivity
                     .set_text(&proxy.get_connectivity().unwrap().to_string());
             }
+             */
         }
     }
     impl WidgetImpl for NetworkMonitorPage {}

--- a/ashpd-demo/src/portals/desktop/notification.rs
+++ b/ashpd-demo/src/portals/desktop/notification.rs
@@ -61,10 +61,10 @@ impl NotificationPage {
     pub fn send_notification(&self) -> zbus::fdo::Result<()> {
         let self_ = imp::NotificationPage::from_instance(self);
 
-        let notification_id = self_.id_entry.get_text();
-        let title = self_.title_entry.get_text();
-        let body = self_.body_entry.get_text();
-
+        let notification_id = self_.id_entry.text();
+        let title = self_.title_entry.text();
+        let body = self_.body_entry.text();
+        /*
         let connection = zbus::Connection::new_session()?;
         let proxy = NotificationProxy::new(&connection);
         proxy.add_notification(
@@ -77,6 +77,7 @@ impl NotificationPage {
                 .button(Button::new("Copy", "copy").target(Value::U32(32).into()))
                 .button(Button::new("Delete", "delete").target(Value::U32(40).into())),
         )?;
+         */
 
         Ok(())
     }

--- a/ashpd-demo/src/portals/desktop/notification.rs
+++ b/ashpd-demo/src/portals/desktop/notification.rs
@@ -64,20 +64,23 @@ impl NotificationPage {
         let notification_id = self_.id_entry.text();
         let title = self_.title_entry.text();
         let body = self_.body_entry.text();
-        /*
-        let connection = zbus::Connection::new_session()?;
-        let proxy = NotificationProxy::new(&connection);
-        proxy.add_notification(
-            &notification_id,
-            Notification::new("Contrast")
-                .default_action("open")
-                .default_action_target(Value::U32(100).into())
-                .body("color copied to clipboard")
-                .priority(Priority::High)
-                .button(Button::new("Copy", "copy").target(Value::U32(32).into()))
-                .button(Button::new("Delete", "delete").target(Value::U32(40).into())),
-        )?;
-         */
+        gtk_macros::spawn!(async move {
+            let cnx = zbus::azync::Connection::new_session().await.unwrap();
+            let proxy = NotificationProxy::new(&cnx).await.unwrap();
+            proxy
+                .add_notification(
+                    &notification_id,
+                    Notification::new(&title)
+                        .default_action("open")
+                        .default_action_target(Value::U32(100).into())
+                        .body(&body)
+                        .priority(Priority::High)
+                        .button(Button::new("Copy", "copy").target(Value::U32(32).into()))
+                        .button(Button::new("Delete", "delete").target(Value::U32(40).into())),
+                )
+                .await
+                .unwrap();
+        });
 
         Ok(())
     }

--- a/ashpd-demo/src/portals/desktop/open_uri.rs
+++ b/ashpd-demo/src/portals/desktop/open_uri.rs
@@ -70,14 +70,6 @@ async fn open_uri(
 ) -> Result<(), ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = open_uri::OpenURIProxy::new(&connection).await?;
-    proxy
-        .open_uri(
-            window,
-            uri,
-            open_uri::OpenFileOptions::default()
-                .ask(ask)
-                .writeable(writeable),
-        )
-        .await?;
+    proxy.open_uri(window, uri, writeable, ask).await?;
     Ok(())
 }

--- a/ashpd-demo/src/portals/desktop/screenshot.rs
+++ b/ashpd-demo/src/portals/desktop/screenshot.rs
@@ -100,7 +100,7 @@ impl ScreenshotPage {
 
             if let Ok(screenshot) = take_screenshot(identifier, interactive, modal).await
             {
-                let file = gio::File::for_uri(&screenshot.uri);
+                let file = gio::File::for_uri(&screenshot.uri());
                 self_.screenshot_photo.set_file(Some(&file));
                 self_.revealer.show(); // Revealer has a weird issue where it still
                                  // takes space even if it's child is hidden
@@ -118,22 +118,13 @@ async fn take_screenshot(
 ) -> Result<screenshot::Screenshot, ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = screenshot::ScreenshotProxy::new(&connection).await?;
-    let screenshot = proxy
-        .screenshot(
-            window,
-            screenshot::ScreenshotOptions::default()
-                .interactive(interactive)
-                .modal(modal),
-        )
-        .await?;
+    let screenshot = proxy.screenshot(window, interactive, modal).await?;
     Ok(screenshot)
 }
 
 async fn pick_color(window: WindowIdentifier) -> Result<screenshot::Color, ashpd::Error> {
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = screenshot::ScreenshotProxy::new(&connection).await?;
-    let color = proxy
-        .pick_color(window, screenshot::PickColorOptions::default())
-        .await?;
+    let color = proxy.pick_color(window).await?;
     Ok(color)
 }

--- a/ashpd-demo/src/portals/desktop/wallpaper.rs
+++ b/ashpd-demo/src/portals/desktop/wallpaper.rs
@@ -113,13 +113,7 @@ async fn set_from_uri(
     let connection = zbus::azync::Connection::new_session().await?;
     let proxy = wallpaper::WallpaperProxy::new(&connection).await?;
     proxy
-        .set_wallpaper_uri(
-            window,
-            uri,
-            wallpaper::WallpaperOptions::default()
-                .show_preview(show_preview)
-                .set_on(set_on),
-        )
+        .set_wallpaper_uri(window, uri, show_preview, set_on)
         .await?;
     Ok(())
 }

--- a/ashpd-demo/src/portals/documents.rs
+++ b/ashpd-demo/src/portals/documents.rs
@@ -1,0 +1,64 @@
+use crate::config;
+use ashpd::documents::DocumentsProxy;
+use ashpd::zbus;
+use glib::clone;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+mod imp {
+    use adw::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    use super::*;
+
+    #[derive(Debug, CompositeTemplate, Default)]
+    #[template(resource = "/com/belmoussaoui/ashpd/demo/documents.ui")]
+    pub struct DocumentsPage {
+        #[template_child]
+        mount_point: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for DocumentsPage {
+        const NAME: &'static str = "DocumentsPage";
+        type Type = super::DocumentsPage;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+    impl ObjectImpl for DocumentsPage {
+        fn constructed(&self, _obj: &Self::Type) {
+            let ctx = glib::MainContext::default();
+            let mount_point_label = self.mount_point.get();
+            ctx.spawn_local(clone!(@weak mount_point_label => async move {
+                            let cnx = zbus::azync::Connection::new_session().await.unwrap();
+                            let proxy = DocumentsProxy::new(&cnx).await.unwrap();
+                            let info = proxy.list(config::APP_ID).await;
+                            println!("{:#?}", info);
+                            let mount_point = proxy.mount_point().await;
+                            println!("{:#?}", mount_point);
+            //                mount_point_label.set_text(&mount_point);
+                        }));
+        }
+    }
+
+    impl WidgetImpl for DocumentsPage {}
+    impl BinImpl for DocumentsPage {}
+}
+
+glib::wrapper! {
+    pub struct DocumentsPage(ObjectSubclass<imp::DocumentsPage>) @extends gtk::Widget, adw::Bin;
+}
+
+impl DocumentsPage {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create a DocumentsPage")
+    }
+}

--- a/ashpd-demo/src/portals/mod.rs
+++ b/ashpd-demo/src/portals/mod.rs
@@ -1,1 +1,4 @@
 pub mod desktop;
+mod documents;
+
+pub use documents::DocumentsPage;

--- a/ashpd-demo/src/sidebar_row.rs
+++ b/ashpd-demo/src/sidebar_row.rs
@@ -37,14 +37,14 @@ mod imp {
         fn properties() -> &'static [ParamSpec] {
             static PROPS: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
                 vec![
-                    ParamSpec::string(
+                    ParamSpec::new_string(
                         "label",
                         "Label",
                         "Row Label",
                         Some(""),
                         ParamFlags::READWRITE,
                     ),
-                    ParamSpec::string(
+                    ParamSpec::new_string(
                         "page-name",
                         "Page Name",
                         "Page Name",
@@ -55,23 +55,22 @@ mod imp {
             });
             PROPS.as_ref()
         }
-        fn get_property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
-            match pspec.get_name() {
-                "label" => self.label.get_label().to_value(),
+        fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
+            match pspec.name() {
+                "label" => self.label.label().to_value(),
                 "page-name" => self.name.borrow().to_value(),
                 _ => unimplemented!(),
             }
         }
         fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {
-            match pspec.get_name() {
+            match pspec.name() {
                 "label" => {
-                    self.label
-                        .set_text(&value.get::<String>().unwrap().unwrap());
+                    self.label.set_text(&value.get::<String>().unwrap());
                 }
                 "page-name" => {
                     self.name
                         .borrow_mut()
-                        .replace(value.get::<String>().unwrap().unwrap());
+                        .replace(value.get::<String>().unwrap());
                 }
                 _ => unimplemented!(),
             }
@@ -91,13 +90,16 @@ impl SidebarRow {
     }
 
     pub fn title(&self) -> Option<String> {
-        self.get_property("label").unwrap().get::<String>().unwrap()
+        self.property("label")
+            .unwrap()
+            .get::<Option<String>>()
+            .unwrap()
     }
 
     pub fn name(&self) -> String {
-        self.get_property("page-name")
+        self.property("page-name")
             .unwrap()
-            .get::<String>()
+            .get::<Option<String>>()
             .unwrap()
             .unwrap_or_else(|| "welcome".to_string())
     }

--- a/ashpd-demo/src/widgets/color_widget.rs
+++ b/ashpd-demo/src/widgets/color_widget.rs
@@ -29,7 +29,7 @@ mod imp {
         fn properties() -> &'static [ParamSpec] {
             use once_cell::sync::Lazy;
             static PROPS: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-                vec![ParamSpec::boxed(
+                vec![ParamSpec::new_boxed(
                     "rgba",
                     "RGBA",
                     "Color RGBA",
@@ -40,8 +40,8 @@ mod imp {
             PROPS.as_ref()
         }
 
-        fn get_property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> glib::Value {
-            match pspec.get_name() {
+        fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> glib::Value {
+            match pspec.name() {
                 "rgba" => self.rgba.borrow().to_value(),
                 _ => unimplemented!(),
             }
@@ -54,11 +54,9 @@ mod imp {
             value: &glib::Value,
             pspec: &ParamSpec,
         ) {
-            match pspec.get_name() {
+            match pspec.name() {
                 "rgba" => {
-                    self.rgba
-                        .borrow_mut()
-                        .replace(value.get().unwrap().unwrap());
+                    self.rgba.borrow_mut().replace(value.get().unwrap());
                 }
                 _ => unimplemented!(),
             }
@@ -77,8 +75,8 @@ mod imp {
                 blue: 228.0 / 255.0,
                 alpha: 1.0,
             });
-            let width = widget.get_width() as f32;
-            let height = widget.get_height() as f32;
+            let width = widget.width() as f32;
+            let height = widget.height() as f32;
             snapshot.append_color(&color, &graphene::Rect::new(0.0, 0.0, width, height));
         }
     }

--- a/ashpd-demo/src/widgets/gst_paintable.rs
+++ b/ashpd-demo/src/widgets/gst_paintable.rs
@@ -233,14 +233,14 @@ mod imp {
     }
 
     impl PaintableImpl for CameraPaintable {
-        fn get_intrinsic_height(&self, _paintable: &Self::Type) -> i32 {
+        fn intrinsic_height(&self, _paintable: &Self::Type) -> i32 {
             if let Some((_, height)) = *self.size.borrow() {
                 height as i32
             } else {
                 0
             }
         }
-        fn get_intrinsic_width(&self, _paintable: &Self::Type) -> i32 {
+        fn intrinsic_width(&self, _paintable: &Self::Type) -> i32 {
             if let Some((width, _)) = *self.size.borrow() {
                 width as i32
             } else {
@@ -317,16 +317,16 @@ impl CameraPaintable {
         convert.link(&queue2).unwrap();
         queue2.link(&self_.sink).unwrap();
 
-        let bus = pipeline.get_bus().unwrap();
+        let bus = pipeline.bus().unwrap();
         bus.add_watch_local(move |_, msg| {
             use gst::MessageView;
             match msg.view() {
                 MessageView::Error(err) => {
                     println!(
                         "Error from {:?}: {} ({:?})",
-                        err.get_src().map(|s| s.get_path_string()),
-                        err.get_error(),
-                        err.get_debug()
+                        err.src().map(|s| s.path_string()),
+                        err.error(),
+                        err.debug()
                     );
                 }
                 _ => (),

--- a/ashpd-demo/src/window.rs
+++ b/ashpd-demo/src/window.rs
@@ -11,6 +11,7 @@ use crate::portals::desktop::{
     NetworkMonitorPage, NotificationPage, OpenUriPage, ScreenCastPage, ScreenshotPage,
     WallpaperPage,
 };
+use crate::portals::DocumentsPage;
 use crate::sidebar_row::SidebarRow;
 
 mod imp {
@@ -64,6 +65,7 @@ mod imp {
             AccountPage::static_type();
             NetworkMonitorPage::static_type();
             EmailPage::static_type();
+            DocumentsPage::static_type();
             OpenUriPage::static_type();
             Self::bind_template(klass);
 
@@ -84,14 +86,14 @@ mod imp {
             self.parent_constructed(obj);
 
             let builder = gtk::Builder::from_resource("/com/belmoussaoui/ashpd/demo/shortcuts.ui");
-            let shortcuts = builder.get_object("shortcuts").unwrap();
+            let shortcuts = builder.object("shortcuts").unwrap();
             obj.set_help_overlay(Some(&shortcuts));
 
             // Devel Profile
             if PROFILE == "Devel" {
-                obj.get_style_context().add_class("devel");
+                obj.add_css_class("devel");
             }
-            let row = self.sidebar.get_row_at_index(0).unwrap();
+            let row = self.sidebar.row_at_index(0).unwrap();
             self.sidebar.unselect_row(&row);
             self.sidebar
                 .connect_row_activated(clone!(@weak obj as win => move |_, row| {
@@ -138,7 +140,7 @@ impl ExampleApplicationWindow {
     pub fn save_window_size(&self) -> Result<(), glib::BoolError> {
         let settings = &imp::ExampleApplicationWindow::from_instance(self).settings;
 
-        let size = self.get_default_size();
+        let size = self.default_size();
 
         settings.set_int("window-width", size.0)?;
         settings.set_int("window-height", size.1)?;
@@ -151,9 +153,9 @@ impl ExampleApplicationWindow {
     fn load_window_size(&self) {
         let settings = &imp::ExampleApplicationWindow::from_instance(self).settings;
 
-        let width = settings.get_int("window-width");
-        let height = settings.get_int("window-height");
-        let is_maximized = settings.get_boolean("is-maximized");
+        let width = settings.int("window-width");
+        let height = settings.int("window-height");
+        let is_maximized = settings.boolean("is-maximized");
 
         self.set_default_size(width, height);
 
@@ -167,7 +169,7 @@ impl ExampleApplicationWindow {
         let sidebar_row = row.downcast_ref::<SidebarRow>().unwrap();
         self_.leaflet.navigate(adw::NavigationDirection::Forward);
         let page_name = sidebar_row.name();
-        if self_.stack.get_child_by_name(&page_name).is_some() {
+        if self_.stack.child_by_name(&page_name).is_some() {
             self_.stack.set_visible_child_name(&page_name);
             self_.title_label.set_label(&sidebar_row.title().unwrap());
         } else {

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -100,6 +100,7 @@ impl<'a> AccountProxy<'a> {
     ///
     /// * `window` - Identifier for the window.
     /// * `reason` - A user-visible reason for the request.
+    #[doc(alias = "GetUserInformation")]
     pub async fn user_information(
         &self,
         window: WindowIdentifier,

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -1,14 +1,22 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::account::{AccountProxy, UserInfoOptions}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::account::{AccountProxy, UserInfoOptions},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = AccountProxy::new(&connection).await?;
-//!     let user_info = proxy.user_information(identifier, UserInfoOptions::default().reason("App would like to access user information")).await?;
+//!     let user_info = proxy
+//!         .user_information(
+//!             identifier,
+//!             UserInfoOptions::default().reason("App would like to access user information"),
+//!         )
+//!         .await?;
 //!
 //!     println!("Name: {}", user_info.name);
 //!     println!("ID: {}", user_info.id);
@@ -24,7 +32,7 @@ use crate::{
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// The possible options for a get user information request.
+/// Specified options for a [`AccountProxy::user_information`] request.
 pub struct UserInfoOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -47,7 +55,7 @@ impl UserInfoOptions {
 }
 
 #[derive(Debug, SerializeDict, DeserializeDict, Clone, TypeDict)]
-/// The response of a `user_information` request.
+/// The response of a [`AccountProxy::user_information`] request.
 pub struct UserInfo {
     /// User identifier.
     pub id: String,
@@ -65,6 +73,7 @@ pub struct UserInfo {
 pub struct AccountProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> AccountProxy<'a> {
+    /// Create a new instance of [`AccountProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<AccountProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Account")
@@ -81,8 +90,6 @@ impl<'a> AccountProxy<'a> {
     ///
     /// * `window` - Identifier for the window.
     /// * `options` - A [`UserInfoOptions`].
-    ///
-    /// [`UserInfoOptions`]: ./struct.UserInfoOptions.html
     pub async fn user_information(
         &self,
         window: WindowIdentifier,

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -101,12 +101,12 @@ impl<'a> AccountProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `window` - Identifier for the window.
+    /// * `identifier` - Identifier for the window.
     /// * `reason` - A user-visible reason for the request.
     #[doc(alias = "GetUserInformation")]
     pub async fn user_information(
         &self,
-        window: WindowIdentifier,
+        identifier: WindowIdentifier,
         reason: &str,
     ) -> Result<UserInfo, Error> {
         let options = UserInfoOptions::default().reason(reason);
@@ -114,7 +114,7 @@ impl<'a> AccountProxy<'a> {
             &self.0,
             &options.handle_token,
             "GetUserInformation",
-            &(window, &options),
+            &(identifier, &options),
         )
         .await
     }

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -80,6 +80,7 @@ impl UserInfo {
 /// The portal backend will present the user with a dialog to confirm which (if
 /// any) information to share.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Account")]
 pub struct AccountProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> AccountProxy<'a> {

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -21,10 +21,7 @@
 //! }
 //! ```
 
-use crate::{
-    helpers::{call_request_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_request_method, Error, WindowIdentifier};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use super::{HandleToken, DESTINATION, PATH};
@@ -120,10 +117,5 @@ impl<'a> AccountProxy<'a> {
             &(window, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -35,7 +35,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 /// Specified options for a [`AccountProxy::user_information`] request.
 pub struct UserInfoOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Shown in the dialog to explain why the information is needed.
     reason: Option<String>,
 }
@@ -49,7 +49,7 @@ impl UserInfoOptions {
 
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -96,7 +96,13 @@ impl<'a> AccountProxy<'a> {
         window: WindowIdentifier,
         options: UserInfoOptions,
     ) -> Result<UserInfo, Error> {
-        call_request_method(&self.0, "GetUserInformation", &(window, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "GetUserInformation",
+            &(window, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -95,6 +95,11 @@ impl<'a> AccountProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Gets information about the user.
     ///
     /// # Arguments

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -27,9 +27,11 @@
 
 use crate::{
     helpers::{call_request_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`AccountProxy::user_information`] request.
@@ -78,8 +80,8 @@ impl<'a> AccountProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<AccountProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Account")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -70,6 +70,7 @@ pub struct UserInfo {
 ///
 /// The portal backend will present the user with a dialog to confirm which (if
 /// any) information to share.
+#[derive(Debug)]
 pub struct AccountProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> AccountProxy<'a> {

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -81,7 +81,7 @@ impl<'a> AccountProxy<'a> {
         &self,
         window: WindowIdentifier,
         options: UserInfoOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("GetUserInformation", &(window, options))

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -10,13 +10,15 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = BackgroundProxy::new(&connection).await?;
 //!
-//!     let response = proxy.request_background(
-//!         WindowIdentifier::default(),
-//!         BackgroundOptions::default()
-//!             .autostart(true)
-//!             .command(&["geary"])
-//!             .reason("Automatically fetch your latest mails"),
-//!     ).await?;
+//!     let response = proxy
+//!         .request_background(
+//!             WindowIdentifier::default(),
+//!             BackgroundOptions::default()
+//!                 .autostart(true)
+//!                 .command(&["geary"])
+//!                 .reason("Automatically fetch your latest mails"),
+//!         )
+//!         .await?;
 //!
 //!     println!("{}", response.autostart);
 //!     println!("{}", response.background);
@@ -32,7 +34,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Clone, Default)]
-/// Specified options for a `request_background` request.
+/// Specified options for a [`BackgroundProxy::request_background`] request.
 pub struct BackgroundOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -86,7 +88,7 @@ impl BackgroundOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
-/// The response of a `request_background` request.
+/// The response of a [`BackgroundProxy::request_background`] request.
 pub struct Background {
     /// If the application is allowed to run in the background.
     pub background: bool,
@@ -100,6 +102,7 @@ pub struct Background {
 pub struct BackgroundProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> BackgroundProxy<'a> {
+    /// Create a new instance of [`BackgroundProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<BackgroundProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Background")
@@ -116,8 +119,6 @@ impl<'a> BackgroundProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - [`BackgroundOptions`].
-    ///
-    /// [`BackgroundOptions`]: ./struct.BackgroundOptions.html
     pub async fn request_background(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -129,7 +129,7 @@ impl<'a> BackgroundProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
 
     /// * `reason` - Sets a user-visible reason for the request.
     /// * `auto_start` - Sets whether to auto start the application or not.
@@ -140,7 +140,7 @@ impl<'a> BackgroundProxy<'a> {
     #[doc(alias = "RequestBackground")]
     pub async fn request_background(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         reason: &str,
         auto_start: bool,
         command_line: Option<&[&str]>,
@@ -155,7 +155,7 @@ impl<'a> BackgroundProxy<'a> {
             &self.0,
             &options.handle_token,
             "RequestBackground",
-            &(parent_window, &options),
+            &(identifier, &options),
         )
         .await
     }

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -108,6 +108,7 @@ impl Background {
 /// is allowed to run in the background or started automatically when the user
 /// logs in.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Background")]
 pub struct BackgroundProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> BackgroundProxy<'a> {

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -121,7 +121,7 @@ impl<'a> BackgroundProxy<'a> {
         &self,
         parent_window: WindowIdentifier,
         options: BackgroundOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("RequestBackground", &(parent_window, options))

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -99,6 +99,7 @@ pub struct Background {
 /// The interface lets sandboxed applications request that the application
 /// is allowed to run in the background or started automatically when the user
 /// logs in.
+#[derive(Debug)]
 pub struct BackgroundProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> BackgroundProxy<'a> {

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -37,7 +37,7 @@ use crate::{
 /// Specified options for a [`BackgroundProxy::request_background`] request.
 pub struct BackgroundOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// User-visible reason for the request.
     reason: Option<String>,
     /// `true` if the app also wants to be started automatically at login.
@@ -61,7 +61,7 @@ impl BackgroundOptions {
 
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -125,7 +125,13 @@ impl<'a> BackgroundProxy<'a> {
         parent_window: WindowIdentifier,
         options: BackgroundOptions,
     ) -> Result<Background, Error> {
-        call_request_method(&self.0, "RequestBackground", &(parent_window, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "RequestBackground",
+            &(parent_window, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -28,10 +28,7 @@
 //! ```
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
-use crate::{
-    helpers::{call_request_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_request_method, Error, WindowIdentifier};
 
 use super::{HandleToken, DESTINATION, PATH};
 
@@ -161,10 +158,5 @@ impl<'a> BackgroundProxy<'a> {
             &(parent_window, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -30,8 +30,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     helpers::{call_request_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Clone, Default)]
 /// Specified options for a [`BackgroundProxy::request_background`] request.
@@ -107,8 +109,8 @@ impl<'a> BackgroundProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<BackgroundProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Background")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -134,6 +134,7 @@ impl<'a> BackgroundProxy<'a> {
     /// * `command_line` - Specifies the command line to execute.
     ///     If this is not specified, the Exec line from the desktop file will be
     ///     used.
+    #[doc(alias = "RequestBackground")]
     pub async fn request_background(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -123,6 +123,11 @@ impl<'a> BackgroundProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Requests that the application is allowed to run in the background.
     ///
     /// # Arguments

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -30,13 +30,13 @@ use crate::{
 /// Specified options for a [`CameraProxy::access_camera`] request.
 pub struct CameraAccessOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
 }
 
 impl CameraAccessOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -64,7 +64,8 @@ impl<'a> CameraProxy<'a> {
     ///
     /// * `options` - A [`CameraAccessOptions`].
     pub async fn access_camera(&self, options: CameraAccessOptions) -> Result<(), Error> {
-        call_basic_response_method(&self.0, "AccessCamera", &(options)).await
+        call_basic_response_method(&self.0, &options.handle_token, "AccessCamera", &(&options))
+            .await
     }
 
     /// Open a file descriptor to the PipeWire remote where the camera nodes are

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -21,7 +21,7 @@ use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
-    helpers::{call_basic_response_method, call_method, property},
+    helpers::{call_basic_response_method, call_method},
     Error,
 };
 
@@ -79,11 +79,9 @@ impl<'a> CameraProxy<'a> {
     /// A boolean stating whether there is any cameras available.
     #[doc(alias = "IsCameraPresent")]
     pub async fn is_camera_present(&self) -> Result<bool, Error> {
-        property(&self.0, "IsCameraPresent").await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
+        self.0
+            .get_property::<bool>("IsCameraPresent")
+            .await
+            .map_err(From::from)
     }
 }

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -1,16 +1,15 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use std::collections::HashMap;
-//! use ashpd::desktop::camera::{CameraAccessOptions, CameraProxy};
+//! use ashpd::desktop::camera::CameraProxy;
 //!
 //! pub async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = CameraProxy::new(&connection).await?;
 //!     if proxy.is_camera_present().await? {
-//!         proxy.access_camera(CameraAccessOptions::default()).await?;
+//!         proxy.access_camera().await?;
 //!
-//!         let remote_fd = proxy.open_pipe_wire_remote(HashMap::new()).await?;
+//!         let remote_fd = proxy.open_pipe_wire_remote().await?;
 //!         // pass the remote fd to GStreamer for example
 //!     }
 //!     Ok(())
@@ -30,17 +29,9 @@ use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`CameraProxy::access_camera`] request.
-pub struct CameraAccessOptions {
+struct CameraAccessOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: HandleToken,
-}
-
-impl CameraAccessOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
-    }
 }
 
 /// The interface lets sandboxed applications access camera devices, such as web
@@ -61,11 +52,8 @@ impl<'a> CameraProxy<'a> {
     }
 
     /// Requests an access to the camera.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - A [`CameraAccessOptions`].
-    pub async fn access_camera(&self, options: CameraAccessOptions) -> Result<(), Error> {
+    pub async fn access_camera(&self) -> Result<(), Error> {
+        let options = CameraAccessOptions::default();
         call_basic_response_method(&self.0, &options.handle_token, "AccessCamera", &(&options))
             .await
     }
@@ -74,15 +62,9 @@ impl<'a> CameraProxy<'a> {
     /// available.
     ///
     /// Returns a File descriptor of an open PipeWire remote.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - ?
-    /// FIXME: figure out what are the possible options
-    pub async fn open_pipe_wire_remote(
-        &self,
-        options: HashMap<&str, Value<'_>>,
-    ) -> Result<Fd, Error> {
+    pub async fn open_pipe_wire_remote(&self) -> Result<Fd, Error> {
+        // FIXME: figure out what are the possible options
+        let options: HashMap<&str, Value<'_>> = HashMap::new();
         call_method(&self.0, "OpenPipeWireRemote", &(options)).await
     }
 

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -52,6 +52,7 @@ impl<'a> CameraProxy<'a> {
     }
 
     /// Requests an access to the camera.
+    #[doc(alias = "AccessCamera")]
     pub async fn access_camera(&self) -> Result<(), Error> {
         let options = CameraAccessOptions::default();
         call_basic_response_method(&self.0, &options.handle_token, "AccessCamera", &(&options))
@@ -62,6 +63,7 @@ impl<'a> CameraProxy<'a> {
     /// available.
     ///
     /// Returns a File descriptor of an open PipeWire remote.
+    #[doc(alias = "OpenPipeWireRemote")]
     pub async fn open_pipe_wire_remote(&self) -> Result<Fd, Error> {
         // FIXME: figure out what are the possible options
         let options: HashMap<&str, Value<'_>> = HashMap::new();
@@ -69,6 +71,7 @@ impl<'a> CameraProxy<'a> {
     }
 
     /// A boolean stating whether there is any cameras available.
+    #[doc(alias = "IsCameraPresent")]
     pub async fn is_camera_present(&self) -> Result<bool, Error> {
         property(&self.0, "IsCameraPresent").await
     }

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -43,6 +43,7 @@ impl CameraAccessOptions {
 
 /// The interface lets sandboxed applications access camera devices, such as web
 /// cams.
+#[derive(Debug)]
 pub struct CameraProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> CameraProxy<'a> {

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -58,7 +58,7 @@ impl<'a> CameraProxy<'a> {
     pub async fn access_camera(
         &self,
         options: CameraAccessOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("AccessCamera", &(options))

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -37,6 +37,7 @@ struct CameraAccessOptions {
 /// The interface lets sandboxed applications access camera devices, such as web
 /// cams.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Camera")]
 pub struct CameraProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> CameraProxy<'a> {

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -23,8 +23,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     helpers::{call_basic_response_method, call_method, property},
-    Error, HandleToken,
+    Error,
 };
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`CameraProxy::access_camera`] request.
@@ -51,8 +53,8 @@ impl<'a> CameraProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<CameraProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Camera")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -52,6 +52,11 @@ impl<'a> CameraProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Requests an access to the camera.
     #[doc(alias = "AccessCamera")]
     pub async fn access_camera(&self) -> Result<(), Error> {

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -1,16 +1,15 @@
+//! **Note** this portal doesn't work for sandboxed applications.
 //! # Examples
 //!
 //! Access a [`Device`](crate::desktop::device::Device)
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::device::{AccessDeviceOptions, Device, DeviceProxy};
+//! use ashpd::desktop::device::{Device, DeviceProxy};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = DeviceProxy::new(&connection).await?;
-//!     proxy
-//!         .access_device(6879, &[Device::Speakers], AccessDeviceOptions::default())
-//!         .await?;
+//!     proxy.access_device(6879, &[Device::Speakers]).await?;
 //!     Ok(())
 //! }
 //!
@@ -29,17 +28,9 @@ use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`DeviceProxy::access_device`] request.
-pub struct AccessDeviceOptions {
+struct AccessDeviceOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: HandleToken,
-}
-
-impl AccessDeviceOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
-    }
 }
 
 #[derive(
@@ -97,13 +88,8 @@ impl<'a> DeviceProxy<'a> {
     /// * `pid` - The pid of the application on whose behalf the request is
     ///   made.
     /// * `devices` - A list of devices to request access to.
-    /// * `options` - A [`AccessDeviceOptions`].
-    pub async fn access_device(
-        &self,
-        pid: u32,
-        devices: &[Device],
-        options: AccessDeviceOptions,
-    ) -> Result<(), Error> {
+    pub async fn access_device(&self, pid: u32, devices: &[Device]) -> Result<(), Error> {
+        let options = AccessDeviceOptions::default();
         call_basic_response_method(
             &self.0,
             &options.handle_token,

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -29,13 +29,13 @@ use crate::{
 /// Specified options for a [`DeviceProxy::access_device`] request.
 pub struct AccessDeviceOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
 }
 
 impl AccessDeviceOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -102,7 +102,13 @@ impl<'a> DeviceProxy<'a> {
         devices: &[Device],
         options: AccessDeviceOptions,
     ) -> Result<(), Error> {
-        call_basic_response_method(&self.0, "AccessDevice", &(pid, devices, options)).await
+        call_basic_response_method(
+            &self.0,
+            &options.handle_token,
+            "AccessDevice",
+            &(pid, devices, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -73,6 +73,7 @@ impl Serialize for Device {
 /// devices such as microphones, speakers or cameras. Not a portal in the strict
 /// sense, since the API is not directly accessible to applications inside the
 /// sandbox.
+#[derive(Debug)]
 pub struct DeviceProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DeviceProxy<'a> {

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -19,10 +19,7 @@ use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
 use zvariant::Signature;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
-use crate::{
-    helpers::{call_basic_response_method, property},
-    Error,
-};
+use crate::{helpers::call_basic_response_method, Error};
 
 use super::{HandleToken, DESTINATION, PATH};
 
@@ -104,10 +101,5 @@ impl<'a> DeviceProxy<'a> {
             &(pid, devices, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -22,8 +22,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     helpers::{call_basic_response_method, property},
-    Error, HandleToken,
+    Error,
 };
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`DeviceProxy::access_device`] request.
@@ -81,8 +83,8 @@ impl<'a> DeviceProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<DeviceProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Device")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -67,6 +67,7 @@ impl Serialize for Device {
 /// sense, since the API is not directly accessible to applications inside the
 /// sandbox.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Device")]
 pub struct DeviceProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DeviceProxy<'a> {

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -99,7 +99,7 @@ impl<'a> DeviceProxy<'a> {
         pid: u32,
         devices: &[Device],
         options: AccessDeviceOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("AccessDevice", &(pid, devices, options))

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -1,6 +1,6 @@
 //! # Examples
 //!
-//! Access a [`Device`]
+//! Access a [`Device`](crate::desktop::device::Device)
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::device::{AccessDeviceOptions, Device, DeviceProxy};
@@ -8,11 +8,13 @@
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = DeviceProxy::new(&connection).await?;
-//!     proxy.access_device(6879, &[Device::Speakers], AccessDeviceOptions::default()).await?;
+//!     proxy
+//!         .access_device(6879, &[Device::Speakers], AccessDeviceOptions::default())
+//!         .await?;
 //!     Ok(())
 //! }
+//!
 //! ```
-//! [`Device`]: ./enum.Device.html
 use serde::{Deserialize, Serialize, Serializer};
 use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
 use zvariant::Signature;
@@ -24,7 +26,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// Specified options for a `access_device` request.
+/// Specified options for a [`DeviceProxy::access_device`] request.
 pub struct AccessDeviceOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -74,6 +76,7 @@ impl Serialize for Device {
 pub struct DeviceProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DeviceProxy<'a> {
+    /// Create a new instance of [`DeviceProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<DeviceProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Device")
@@ -92,8 +95,6 @@ impl<'a> DeviceProxy<'a> {
     ///   made.
     /// * `devices` - A list of devices to request access to.
     /// * `options` - A [`AccessDeviceOptions`].
-    ///
-    /// [`AccessDeviceOptions`]: ./struct.AccessDeviceOptions.html
     pub async fn access_device(
         &self,
         pid: u32,

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -82,6 +82,11 @@ impl<'a> DeviceProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Asks for access to a device.
     ///
     /// # Arguments

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -88,6 +88,7 @@ impl<'a> DeviceProxy<'a> {
     /// * `pid` - The pid of the application on whose behalf the request is
     ///   made.
     /// * `devices` - A list of devices to request access to.
+    #[doc(alias = "AccessDevice")]
     pub async fn access_device(&self, pid: u32, devices: &[Device]) -> Result<(), Error> {
         let options = AccessDeviceOptions::default();
         call_basic_response_method(

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -137,7 +137,7 @@ impl<'a> EmailProxy<'a> {
         &self,
         parent_window: WindowIdentifier,
         options: EmailOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("ComposeEmail", &(parent_window, options))

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::email::{EmailOptions, EmailProxy};
-//! use ashpd::{WindowIdentifier};
+//! use ashpd::WindowIdentifier;
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
 //! use zvariant::Fd;
@@ -13,14 +13,16 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = EmailProxy::new(&connection).await?;
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
-//!     proxy.compose_email(
-//!         WindowIdentifier::default(),
-//!         EmailOptions::default()
-//!             .address("test@gmail.com")
-//!             .subject("email subject")
-//!             .body("the pre-filled email body")
-//!             .attach(Fd::from(file.as_raw_fd())),
-//!     ).await?;
+//!     proxy
+//!         .compose_email(
+//!             WindowIdentifier::default(),
+//!             EmailOptions::default()
+//!                 .address("test@gmail.com")
+//!                 .subject("email subject")
+//!                 .body("the pre-filled email body")
+//!                 .attach(Fd::from(file.as_raw_fd())),
+//!         )
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -34,7 +36,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// Specified options for a compose email request.
+/// Specified options for a [`EmailProxy::compose_email`] request.
 pub struct EmailOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -113,6 +115,7 @@ impl EmailOptions {
 pub struct EmailProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> EmailProxy<'a> {
+    /// Create a new instance of [`EmailProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<EmailProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Email")
@@ -132,8 +135,6 @@ impl<'a> EmailProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - [`EmailOptions`].
-    ///
-    /// [`EmailOptions`]: ./struct.EmailOptions.html
     pub async fn compose_email(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -137,6 +137,7 @@ impl<'a> EmailProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `email` - An [`Email`].
+    #[doc(alias = "ComposeEmail")]
     pub async fn compose_email(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -129,6 +129,11 @@ impl<'a> EmailProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Presents a window that lets the user compose an email.
     ///
     /// **Note** that the default email client for the host will need to support

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -32,8 +32,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     helpers::{call_basic_response_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`EmailProxy::compose_email`] request.
@@ -120,8 +122,8 @@ impl<'a> EmailProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<EmailProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Email")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -138,19 +138,19 @@ impl<'a> EmailProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `email` - An [`Email`].
     #[doc(alias = "ComposeEmail")]
     pub async fn compose_email(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         email: Email,
     ) -> Result<(), Error> {
         call_basic_response_method(
             &self.0,
             &email.handle_token,
             "ComposeEmail",
-            &(parent_window, &email),
+            &(identifier, &email),
         )
         .await
     }

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -3,7 +3,7 @@
 //! Compose an email
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::email::{EmailOptions, EmailProxy};
+//! use ashpd::desktop::email::{Email, EmailProxy};
 //! use ashpd::WindowIdentifier;
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
@@ -16,7 +16,7 @@
 //!     proxy
 //!         .compose_email(
 //!             WindowIdentifier::default(),
-//!             EmailOptions::default()
+//!             Email::new()
 //!                 .address("test@gmail.com")
 //!                 .subject("email subject")
 //!                 .body("the pre-filled email body")
@@ -39,7 +39,7 @@ use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`EmailProxy::compose_email`] request.
-pub struct EmailOptions {
+pub struct Email {
     /// A string that will be used as the last element of the handle.
     handle_token: HandleToken,
     /// The email address to send to.
@@ -58,11 +58,10 @@ pub struct EmailOptions {
     attachment_fds: Option<Vec<Fd>>,
 }
 
-impl EmailOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
+impl Email {
+    /// Create a new instance of [`Email`].
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Sets the email address to send the email to.
@@ -132,22 +131,22 @@ impl<'a> EmailProxy<'a> {
     /// Presents a window that lets the user compose an email.
     ///
     /// **Note** that the default email client for the host will need to support
-    /// mailto: URIs following RFC 2368.
+    /// `mailto:` URIs following RFC 2368.
     ///
     /// # Arguments
     ///
     /// * `parent_window` - Identifier for the application window.
-    /// * `options` - [`EmailOptions`].
+    /// * `email` - An [`Email`].
     pub async fn compose_email(
         &self,
         parent_window: WindowIdentifier,
-        options: EmailOptions,
+        email: Email,
     ) -> Result<(), Error> {
         call_basic_response_method(
             &self.0,
-            &options.handle_token,
+            &email.handle_token,
             "ComposeEmail",
-            &(parent_window, &options),
+            &(parent_window, &email),
         )
         .await
     }

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -112,6 +112,7 @@ impl EmailOptions {
 }
 
 /// The interface lets sandboxed applications request sending an email.
+#[derive(Debug)]
 pub struct EmailProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> EmailProxy<'a> {

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -114,6 +114,7 @@ impl Email {
 
 /// The interface lets sandboxed applications request sending an email.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Email")]
 pub struct EmailProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> EmailProxy<'a> {

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -39,7 +39,7 @@ use crate::{
 /// Specified options for a [`EmailProxy::compose_email`] request.
 pub struct EmailOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// The email address to send to.
     address: Option<String>,
     /// The email addresses to send to.
@@ -59,7 +59,7 @@ pub struct EmailOptions {
 impl EmailOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -141,7 +141,13 @@ impl<'a> EmailProxy<'a> {
         parent_window: WindowIdentifier,
         options: EmailOptions,
     ) -> Result<(), Error> {
-        call_basic_response_method(&self.0, "ComposeEmail", &(parent_window, options)).await
+        call_basic_response_method(
+            &self.0,
+            &options.handle_token,
+            "ComposeEmail",
+            &(parent_window, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -30,10 +30,7 @@
 use zvariant::Fd;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
-use crate::{
-    helpers::{call_basic_response_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_basic_response_method, Error, WindowIdentifier};
 
 use super::{HandleToken, DESTINATION, PATH};
 
@@ -156,10 +153,5 @@ impl<'a> EmailProxy<'a> {
             &(parent_window, &email),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -417,7 +417,7 @@ impl<'a> FileChooserProxy<'a> {
         parent_window: WindowIdentifier,
         title: &str,
         options: OpenFileOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("OpenFile", &(parent_window, title, options))
@@ -440,7 +440,7 @@ impl<'a> FileChooserProxy<'a> {
         parent_window: WindowIdentifier,
         title: &str,
         options: SaveFileOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("SaveFile", &(parent_window, title, options))
@@ -468,7 +468,7 @@ impl<'a> FileChooserProxy<'a> {
         parent_window: WindowIdentifier,
         title: &str,
         options: SaveFilesOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("SaveFiles", &(parent_window, title, options))

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -417,13 +417,13 @@ impl<'a> FileChooserProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`OpenFileOptions`].
     #[doc(alias = "OpenFile")]
     pub async fn open_file(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         title: &str,
         options: OpenFileOptions,
     ) -> Result<SelectedFiles, Error> {
@@ -431,7 +431,7 @@ impl<'a> FileChooserProxy<'a> {
             &self.0,
             &options.handle_token,
             "OpenFile",
-            &(parent_window, title, &options),
+            &(identifier, title, &options),
         )
         .await
     }
@@ -440,13 +440,13 @@ impl<'a> FileChooserProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFileOptions`].
     #[doc(alias = "SaveFile")]
     pub async fn save_file(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         title: &str,
         options: SaveFileOptions,
     ) -> Result<SelectedFiles, Error> {
@@ -454,7 +454,7 @@ impl<'a> FileChooserProxy<'a> {
             &self.0,
             &options.handle_token,
             "SaveFile",
-            &(parent_window, title, &options),
+            &(identifier, title, &options),
         )
         .await
     }
@@ -468,13 +468,13 @@ impl<'a> FileChooserProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFilesOptions`].
     #[doc(alias = "SaveFiles")]
     pub async fn save_files(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         title: &str,
         options: SaveFilesOptions,
     ) -> Result<SelectedFiles, Error> {
@@ -482,7 +482,7 @@ impl<'a> FileChooserProxy<'a> {
             &self.0,
             &options.handle_token,
             "SaveFiles",
-            &(parent_window, title, &options),
+            &(identifier, title, &options),
         )
         .await
     }

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -1,33 +1,33 @@
 //! # Examples
 //!
-//! Opening a file
+//! ## Opening a file
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::file_chooser::{
-//!     Choice, FileChooserProxy, FileFilter, OpenFileOptions,
-//! };
+//! use ashpd::desktop::file_chooser::{Choice, FileChooserProxy, FileFilter, OpenFileOptions};
 //! use ashpd::WindowIdentifier;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = FileChooserProxy::new(&connection).await?;
-//!     let files = proxy.open_file(
-//!         WindowIdentifier::default(),
-//!         "open a file to read",
-//!         OpenFileOptions::default()
-//!             .accept_label("read")
-//!             .modal(true)
-//!             .multiple(true)
-//!             .choice(
-//!                 Choice::new("encoding", "Encoding", "latin15")
-//!                     .insert("utf8", "Unicode (UTF-8)")
-//!                     .insert("latin15", "Western"),
-//!             )
-//!             // A trick to have a checkbox
-//!             .choice(Choice::new("re-encode", "Re-encode", "false"))
-//!             .filter(FileFilter::new("SVG Image").mimetype("image/svg+xml")),
-//!     ).await?;
+//!     let files = proxy
+//!         .open_file(
+//!             WindowIdentifier::default(),
+//!             "open a file to read",
+//!             OpenFileOptions::default()
+//!                 .accept_label("read")
+//!                 .modal(true)
+//!                 .multiple(true)
+//!                 .choice(
+//!                     Choice::new("encoding", "Encoding", "latin15")
+//!                         .insert("utf8", "Unicode (UTF-8)")
+//!                         .insert("latin15", "Western"),
+//!                 )
+//!                 // A trick to have a checkbox
+//!                 .choice(Choice::new("re-encode", "Re-encode", "false"))
+//!                 .filter(FileFilter::new("SVG Image").mimetype("image/svg+xml")),
+//!         )
+//!         .await?;
 //!
 //!     println!("{:#?}", files);
 //!
@@ -35,7 +35,7 @@
 //! }
 //! ```
 //!
-//! Ask to save a file
+//! ## Ask to save a file
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::file_chooser::{FileChooserProxy, FileFilter, SaveFileOptions};
@@ -44,15 +44,17 @@
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FileChooserProxy::new(&connection).await?;
-//!     let files = proxy.save_file(
-//!         WindowIdentifier::default(),
-//!         "open a file to write",
-//!         SaveFileOptions::default()
-//!             .accept_label("write")
-//!             .current_name("image.jpg")
-//!             .modal(true)
-//!             .filter(FileFilter::new("JPEG Image").glob("*.jpg")),
-//!     ).await?;
+//!     let files = proxy
+//!         .save_file(
+//!             WindowIdentifier::default(),
+//!             "open a file to write",
+//!             SaveFileOptions::default()
+//!                 .accept_label("write")
+//!                 .current_name("image.jpg")
+//!                 .modal(true)
+//!                 .filter(FileFilter::new("JPEG Image").glob("*.jpg")),
+//!         )
+//!         .await?;
 //!
 //!     println!("{:#?}", files);
 //!
@@ -60,7 +62,7 @@
 //! }
 //! ```
 //!
-//! Ask to save multiple files
+//! ## Ask to save multiple files
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::file_chooser::{FileChooserProxy, SaveFilesOptions};
@@ -70,15 +72,17 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = FileChooserProxy::new(&connection).await?;
-//!     let files = proxy.save_files(
-//!         WindowIdentifier::default(),
-//!         "open files to write",
-//!         SaveFilesOptions::default()
-//!             .accept_label("write files")
-//!             .modal(true)
-//!             .current_folder("/home/bilelmoussaoui/Pictures")
-//!             .files(&["test.jpg", "awesome.png"]),
-//!     ).await?;
+//!     let files = proxy
+//!         .save_files(
+//!             WindowIdentifier::default(),
+//!             "open files to write",
+//!             SaveFilesOptions::default()
+//!                 .accept_label("write files")
+//!                 .modal(true)
+//!                 .current_folder("/home/bilelmoussaoui/Pictures")
+//!                 .files(&["test.jpg", "awesome.png"]),
+//!         )
+//!         .await?;
 //!
 //!     println!("{:#?}", files);
 //!
@@ -174,7 +178,7 @@ impl Choice {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// Specified options for a `open_file` request.
+/// Specified options for a [`FileChooserProxy::open_file`] request.
 pub struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -245,7 +249,7 @@ impl OpenFileOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for a save file request.
+/// Specified options for a [`FileChooserProxy::save_file`] request.
 pub struct SaveFileOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -324,7 +328,7 @@ impl SaveFileOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for a save files request.
+/// Specified options for a [`FileChooserProxy::save_files`] request.
 pub struct SaveFilesOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -379,7 +383,7 @@ impl SaveFilesOptions {
 }
 
 #[derive(Debug, TypeDict, SerializeDict, Clone, DeserializeDict)]
-/// A response to an open/save file request.
+/// A response to a [`FileChooserProxy::open_file`]/[`FileChooserProxy::save_file`]/[`FileChooserProxy::save_files`] request.
 pub struct SelectedFiles {
     /// The selected files uris.
     pub uris: Vec<String>,
@@ -393,6 +397,7 @@ pub struct SelectedFiles {
 pub struct FileChooserProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileChooserProxy<'a> {
+    /// Create a new instance of [`FileChooserProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FileChooserProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.FileChooser")
@@ -410,8 +415,6 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`OpenFileOptions`].
-    ///
-    /// [`OpenFileOptions`]: ./struct.OpenFileOptions.html
     pub async fn open_file(
         &self,
         parent_window: WindowIdentifier,
@@ -428,8 +431,6 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFileOptions`].
-    ///
-    /// [`SaveFileOptions`]: ./struct.SaveFileOptions.html
     pub async fn save_file(
         &self,
         parent_window: WindowIdentifier,
@@ -451,8 +452,6 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFilesOptions`].
-    ///
-    /// [`SaveFilesOptions`]: ./struct.SaveFilesOptions.html
     pub async fn save_files(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -394,6 +394,7 @@ pub struct SelectedFiles {
 /// The interface lets sandboxed applications ask the user for access to files
 /// outside the sandbox. The portal backend will present the user with a file
 /// chooser dialog.
+#[derive(Debug)]
 pub struct FileChooserProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileChooserProxy<'a> {

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -93,9 +93,10 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{HandleToken, DESTINATION, PATH};
 use crate::{
     helpers::{call_request_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(Serialize, Deserialize, Type, Clone, Debug)]
@@ -402,8 +403,8 @@ impl<'a> FileChooserProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FileChooserProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.FileChooser")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -411,6 +411,11 @@ impl<'a> FileChooserProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Asks to open one or more files.
     ///
     /// # Arguments

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -4,7 +4,6 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::file_chooser::{Choice, FileChooserProxy, FileFilter, OpenFileOptions};
-//! use ashpd::WindowIdentifier;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
@@ -12,20 +11,20 @@
 //!     let proxy = FileChooserProxy::new(&connection).await?;
 //!     let files = proxy
 //!         .open_file(
-//!             WindowIdentifier::default(),
+//!             Default::default(),
 //!             "open a file to read",
 //!             OpenFileOptions::default()
 //!                 .accept_label("read")
 //!                 .modal(true)
 //!                 .multiple(true)
-//!                 .choice(
+//!                 .add_choice(
 //!                     Choice::new("encoding", "Encoding", "latin15")
 //!                         .insert("utf8", "Unicode (UTF-8)")
 //!                         .insert("latin15", "Western"),
 //!                 )
 //!                 // A trick to have a checkbox
-//!                 .choice(Choice::new("re-encode", "Re-encode", "false"))
-//!                 .filter(FileFilter::new("SVG Image").mimetype("image/svg+xml")),
+//!                 .add_choice(Choice::boolean("re-encode", "Re-encode", false))
+//!                 .add_filter(FileFilter::new("SVG Image").mimetype("image/svg+xml")),
 //!         )
 //!         .await?;
 //!
@@ -39,20 +38,19 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::file_chooser::{FileChooserProxy, FileFilter, SaveFileOptions};
-//! use ashpd::WindowIdentifier;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FileChooserProxy::new(&connection).await?;
 //!     let files = proxy
 //!         .save_file(
-//!             WindowIdentifier::default(),
+//!             Default::default(),
 //!             "open a file to write",
 //!             SaveFileOptions::default()
 //!                 .accept_label("write")
 //!                 .current_name("image.jpg")
 //!                 .modal(true)
-//!                 .filter(FileFilter::new("JPEG Image").glob("*.jpg")),
+//!                 .add_filter(FileFilter::new("JPEG Image").glob("*.jpg")),
 //!         )
 //!         .await?;
 //!
@@ -66,7 +64,6 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::file_chooser::{FileChooserProxy, SaveFilesOptions};
-//! use ashpd::WindowIdentifier;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
@@ -74,7 +71,7 @@
 //!     let proxy = FileChooserProxy::new(&connection).await?;
 //!     let files = proxy
 //!         .save_files(
-//!             WindowIdentifier::default(),
+//!             Default::default(),
 //!             "open files to write",
 //!             SaveFilesOptions::default()
 //!                 .accept_label("write files")
@@ -140,6 +137,17 @@ impl FileFilter {
 pub struct Choice(String, String, Vec<(String, String)>, String);
 
 impl Choice {
+    /// Creates a checkbox choice.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - A unique identifier of the choice.
+    /// * `label` - user-visible name of the choice.
+    /// * `state` - the initial state value.
+    pub fn boolean(id: &str, label: &str, state: bool) -> Self {
+        Self::new(id, label, &state.to_string())
+    }
+
     /// Creates a new choice.
     ///
     /// # Arguments
@@ -200,12 +208,6 @@ pub struct OpenFileOptions {
 }
 
 impl OpenFileOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
-    }
-
     /// Sets a user-visible string to the "accept" button.
     pub fn accept_label(mut self, accept_label: &str) -> Self {
         self.accept_label = Some(accept_label.to_string());
@@ -231,7 +233,7 @@ impl OpenFileOptions {
     }
 
     /// Adds a files filter.
-    pub fn filter(mut self, filter: FileFilter) -> Self {
+    pub fn add_filter(mut self, filter: FileFilter) -> Self {
         self.filters.push(filter);
         self
     }
@@ -243,7 +245,7 @@ impl OpenFileOptions {
     }
 
     /// Adds a choice.
-    pub fn choice(mut self, choice: Choice) -> Self {
+    pub fn add_choice(mut self, choice: Choice) -> Self {
         self.choices.push(choice);
         self
     }
@@ -273,12 +275,6 @@ pub struct SaveFileOptions {
 }
 
 impl SaveFileOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
-    }
-
     /// Sets a user-visible string to the "accept" button.
     pub fn accept_label(mut self, accept_label: &str) -> Self {
         self.accept_label = Some(accept_label.to_string());
@@ -310,7 +306,7 @@ impl SaveFileOptions {
     }
 
     /// Adds a files filter.
-    pub fn filter(mut self, filter: FileFilter) -> Self {
+    pub fn add_filter(mut self, filter: FileFilter) -> Self {
         self.filters.push(filter);
         self
     }
@@ -322,7 +318,7 @@ impl SaveFileOptions {
     }
 
     /// Adds a choice.
-    pub fn choice(mut self, choice: Choice) -> Self {
+    pub fn add_choice(mut self, choice: Choice) -> Self {
         self.choices.push(choice);
         self
     }
@@ -346,12 +342,6 @@ pub struct SaveFilesOptions {
 }
 
 impl SaveFilesOptions {
-    /// Sets the handle token.
-    pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = handle_token;
-        self
-    }
-
     /// Sets a user-visible string to the "accept" button.
     pub fn accept_label(mut self, accept_label: &str) -> Self {
         self.accept_label = Some(accept_label.to_string());
@@ -365,7 +355,7 @@ impl SaveFilesOptions {
     }
 
     /// Adds a choice.
-    pub fn choice(mut self, choice: Choice) -> Self {
+    pub fn add_choice(mut self, choice: Choice) -> Self {
         self.choices.push(choice);
         self
     }
@@ -386,10 +376,20 @@ impl SaveFilesOptions {
 #[derive(Debug, TypeDict, SerializeDict, Clone, DeserializeDict)]
 /// A response to a [`FileChooserProxy::open_file`]/[`FileChooserProxy::save_file`]/[`FileChooserProxy::save_files`] request.
 pub struct SelectedFiles {
+    uris: Vec<String>,
+    choices: Option<Vec<(String, String)>>,
+}
+
+impl SelectedFiles {
     /// The selected files uris.
-    pub uris: Vec<String>,
+    pub fn uris(&self) -> &[String] {
+        self.uris.as_slice()
+    }
+
     /// The selected value of each choice as a tuple of (key, value)
-    pub choices: Option<Vec<(String, String)>>,
+    pub fn choices(&self) -> &[(String, String)] {
+        self.choices.as_deref().unwrap_or_default()
+    }
 }
 
 /// The interface lets sandboxed applications ask the user for access to files

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -181,7 +181,7 @@ impl Choice {
 /// Specified options for a [`FileChooserProxy::open_file`] request.
 pub struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Label for the accept button. Mnemonic underlines are allowed.
     accept_label: Option<String>,
     /// Whether the dialog should be modal.
@@ -201,7 +201,7 @@ pub struct OpenFileOptions {
 impl OpenFileOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -252,7 +252,7 @@ impl OpenFileOptions {
 /// Specified options for a [`FileChooserProxy::save_file`] request.
 pub struct SaveFileOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Label for the accept button. Mnemonic underlines are allowed.
     accept_label: Option<String>,
     /// Whether the dialog should be modal.
@@ -274,7 +274,7 @@ pub struct SaveFileOptions {
 impl SaveFileOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -331,7 +331,7 @@ impl SaveFileOptions {
 /// Specified options for a [`FileChooserProxy::save_files`] request.
 pub struct SaveFilesOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Label for the accept button. Mnemonic underlines are allowed.
     accept_label: Option<String>,
     /// Whether the dialog should be modal.
@@ -347,7 +347,7 @@ pub struct SaveFilesOptions {
 impl SaveFilesOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -422,7 +422,13 @@ impl<'a> FileChooserProxy<'a> {
         title: &str,
         options: OpenFileOptions,
     ) -> Result<SelectedFiles, Error> {
-        call_request_method(&self.0, "OpenFile", &(parent_window, title, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "OpenFile",
+            &(parent_window, title, &options),
+        )
+        .await
     }
 
     /// Asks for a location to save a file.
@@ -438,7 +444,13 @@ impl<'a> FileChooserProxy<'a> {
         title: &str,
         options: SaveFileOptions,
     ) -> Result<SelectedFiles, Error> {
-        call_request_method(&self.0, "SaveFile", &(parent_window, title, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "SaveFile",
+            &(parent_window, title, &options),
+        )
+        .await
     }
 
     /// Asks for a folder as a location to save one or more files.
@@ -459,7 +471,13 @@ impl<'a> FileChooserProxy<'a> {
         title: &str,
         options: SaveFilesOptions,
     ) -> Result<SelectedFiles, Error> {
-        call_request_method(&self.0, "SaveFiles", &(parent_window, title, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "SaveFiles",
+            &(parent_window, title, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -91,10 +91,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use super::{HandleToken, DESTINATION, PATH};
-use crate::{
-    helpers::{call_request_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_request_method, Error, WindowIdentifier};
 
 #[derive(Serialize, Deserialize, Type, Clone, Debug)]
 /// A file filter, to limit the available file choices to a mimetype or a glob
@@ -488,10 +485,5 @@ impl<'a> FileChooserProxy<'a> {
             &(parent_window, title, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -417,6 +417,7 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`OpenFileOptions`].
+    #[doc(alias = "OpenFile")]
     pub async fn open_file(
         &self,
         parent_window: WindowIdentifier,
@@ -439,6 +440,7 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFileOptions`].
+    #[doc(alias = "SaveFile")]
     pub async fn save_file(
         &self,
         parent_window: WindowIdentifier,
@@ -466,6 +468,7 @@ impl<'a> FileChooserProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `title` - Title for the file chooser dialog.
     /// * `options` - [`SaveFilesOptions`].
+    #[doc(alias = "SaveFiles")]
     pub async fn save_files(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -396,6 +396,7 @@ impl SelectedFiles {
 /// outside the sandbox. The portal backend will present the user with a file
 /// chooser dialog.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.FileChooser")]
 pub struct FileChooserProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileChooserProxy<'a> {

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -93,6 +93,11 @@ impl<'a> GameModeProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Query the GameMode status for a process.
     /// If the caller is running inside a sandbox with pid namespace isolation,
     /// the pid will be translated to the respective host pid.

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -18,7 +18,10 @@
 //! ```
 use std::os::unix::io::AsRawFd;
 
-use crate::Error;
+use crate::{
+    helpers::{call_method, property},
+    Error,
+};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::Type;
@@ -101,11 +104,7 @@ impl<'a> GameModeProxy<'a> {
     ///
     /// * `pid` - Process id to query the GameMode status of.
     pub async fn query_status(&self, pid: i32) -> Result<GameModeStatus, Error> {
-        self.0
-            .call_method("QueryStatus", &(pid))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "QueryStatus", &(pid)).await
     }
 
     /// Query the GameMode status for a process.
@@ -124,11 +123,7 @@ impl<'a> GameModeProxy<'a> {
         F: AsRawFd + Type + Serialize,
         R: AsRawFd + Type + Serialize,
     {
-        self.0
-            .call_method("QueryStatusByPIDFd", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "QueryStatusByPIDFd", &(target, requester)).await
     }
 
     /// Query the GameMode status for a process.
@@ -142,11 +137,7 @@ impl<'a> GameModeProxy<'a> {
         target: i32,
         requester: i32,
     ) -> Result<GameModeStatus, Error> {
-        self.0
-            .call_method("QueryStatusByPid", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "QueryStatusByPid", &(target, requester)).await
     }
 
     /// Register a game with GameMode and thus request GameMode to be activated.
@@ -160,11 +151,7 @@ impl<'a> GameModeProxy<'a> {
     ///
     /// * `pid` - Process id of the game to register.
     pub async fn register_game(&self, pid: i32) -> Result<RegisterStatus, Error> {
-        self.0
-            .call_method("RegisterGame", &(pid))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "RegisterGame", &(pid)).await
     }
 
     /// Register a game with GameMode.
@@ -183,11 +170,7 @@ impl<'a> GameModeProxy<'a> {
         F: AsRawFd + Type + Serialize,
         R: AsRawFd + Type + Serialize,
     {
-        self.0
-            .call_method("RegisterGameByPIDFd", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "RegisterGameByPIDFd", &(target, requester)).await
     }
 
     /// Register a game with GameMode.
@@ -201,11 +184,7 @@ impl<'a> GameModeProxy<'a> {
         target: i32,
         requester: i32,
     ) -> Result<RegisterStatus, Error> {
-        self.0
-            .call_method("RegisterGameByPid", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "RegisterGameByPid", &(target, requester)).await
     }
 
     /// Un-register a game from GameMode.
@@ -218,11 +197,7 @@ impl<'a> GameModeProxy<'a> {
     ///
     /// `pid` - Process id of the game to un-register.
     pub async fn unregister_game(&self, pid: i32) -> Result<UnregisterStatus, Error> {
-        self.0
-            .call_method("UnregisterGame", &(pid))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "UnregisterGame", &(pid)).await
     }
 
     /// Un-register a game from GameMode.
@@ -241,11 +216,7 @@ impl<'a> GameModeProxy<'a> {
         F: AsRawFd + Type + Serialize,
         R: AsRawFd + Type + Serialize,
     {
-        self.0
-            .call_method("UnregisterGameByPIDFd", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "UnregisterGameByPIDFd", &(target, requester)).await
     }
 
     /// Un-register a game from GameMode.
@@ -260,18 +231,11 @@ impl<'a> GameModeProxy<'a> {
         target: i32,
         requester: i32,
     ) -> Result<UnregisterStatus, Error> {
-        self.0
-            .call_method("UnregisterGameByPid", &(target, requester))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "UnregisterGameByPid", &(target, requester)).await
     }
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -1,3 +1,5 @@
+//! # Examples
+//!
 //! ```rust,no_run
 //! use ashpd::desktop::game_mode::{GameModeProxy, GameModeStatus};
 //!
@@ -86,6 +88,7 @@ pub enum UnregisterStatus {
 pub struct GameModeProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> GameModeProxy<'a> {
+    /// Create a new instance of [`GameModeProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<GameModeProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.GameMode")

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -20,10 +20,7 @@
 //! ```
 use std::{fmt::Debug, os::unix::io::AsRawFd};
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::Type;
@@ -247,10 +244,5 @@ impl<'a> GameModeProxy<'a> {
             RegisterStatus::Success => Ok(()),
             RegisterStatus::Rejected => Err(Error::RegisterGameRejected),
         }
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -99,6 +99,7 @@ impl<'a> GameModeProxy<'a> {
     /// # Arguments
     ///
     /// * `pid` - Process id to query the GameMode status of.
+    #[doc(alias = "QueryStatus")]
     pub async fn query_status(&self, pid: i32) -> Result<Status, Error> {
         call_method(&self.0, "QueryStatus", &(pid)).await
     }
@@ -110,6 +111,7 @@ impl<'a> GameModeProxy<'a> {
     /// * `target` - Pid file descriptor to query the GameMode status of.
     /// * `requester` - Pid file descriptor of the process requesting the
     ///   information.
+    #[doc(alias = "QueryStatusByPIDFd")]
     pub async fn query_status_by_pidfd<F, R>(
         &self,
         target: F,
@@ -128,6 +130,7 @@ impl<'a> GameModeProxy<'a> {
     ///
     /// * `target` - Process id to query the GameMode status of.
     /// * `requester` - Process id of the process requesting the information.
+    #[doc(alias = "QueryStatusByPid")]
     pub async fn query_status_by_pid(&self, target: i32, requester: i32) -> Result<Status, Error> {
         call_method(&self.0, "QueryStatusByPid", &(target, requester)).await
     }
@@ -142,6 +145,7 @@ impl<'a> GameModeProxy<'a> {
     /// # Arguments
     ///
     /// * `pid` - Process id of the game to register.
+    #[doc(alias = "RegisterGame")]
     pub async fn register_game(&self, pid: i32) -> Result<(), Error> {
         let status = call_method(&self.0, "RegisterGame", &(pid)).await?;
         match status {
@@ -157,6 +161,7 @@ impl<'a> GameModeProxy<'a> {
     /// * `target` - Process file descriptor of the game to register.
     /// * `requester` - Process file descriptor of the process requesting the
     ///   registration.
+    #[doc(alias = "RegisterGameByPIDFd")]
     pub async fn register_game_by_pidfd<F, R>(&self, target: F, requester: R) -> Result<(), Error>
     where
         F: AsRawFd + Type + Serialize + Debug,
@@ -175,6 +180,7 @@ impl<'a> GameModeProxy<'a> {
     ///
     /// * `target` - Process id of the game to register.
     /// * `requester` - Process id of the process requesting the registration.
+    #[doc(alias = "RegisterGameRejected")]
     pub async fn register_game_by_pid(&self, target: i32, requester: i32) -> Result<(), Error> {
         let status = call_method(&self.0, "RegisterGameByPid", &(target, requester)).await?;
         match status {
@@ -192,6 +198,7 @@ impl<'a> GameModeProxy<'a> {
     /// # Arguments
     ///
     /// `pid` - Process id of the game to un-register.
+    #[doc(alias = "UnregisterGame")]
     pub async fn unregister_game(&self, pid: i32) -> Result<(), Error> {
         let status = call_method(&self.0, "UnregisterGame", &(pid)).await?;
         match status {
@@ -207,6 +214,7 @@ impl<'a> GameModeProxy<'a> {
     /// * `target` - Pid file descriptor of the game to un-register.
     /// * `requester` - Pid file descriptor of the process requesting the
     ///   un-registration.
+    #[doc(alias = "UnregisterGameByPIDFd")]
     pub async fn unregister_game_by_pidfd<F, R>(&self, target: F, requester: R) -> Result<(), Error>
     where
         F: AsRawFd + Type + Serialize + Debug,
@@ -226,6 +234,7 @@ impl<'a> GameModeProxy<'a> {
     /// * `target` - Process id of the game to un-register.
     /// * `requester` - Process id of the process requesting the
     ///   un-registration.
+    #[doc(alias = "UnregisterGameByPid")]
     pub async fn unregister_game_by_pid(&self, target: i32, requester: i32) -> Result<(), Error> {
         let status = call_method(&self.0, "UnregisterGameByPid", &(target, requester)).await?;
         match status {

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -78,6 +78,7 @@ enum RegisterStatus {
 /// automatically un-register the client. This might happen with a (small)
 /// delay.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.GameMode")]
 pub struct GameModeProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> GameModeProxy<'a> {

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -29,6 +29,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::Type;
 use zvariant_derive::Type;
 
+use super::{DESTINATION, PATH};
+
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Type)]
 #[repr(i32)]
 /// The status of the game mode.
@@ -93,8 +95,8 @@ impl<'a> GameModeProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<GameModeProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.GameMode")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -18,7 +18,7 @@
 //!     Ok(())
 //! }
 //! ```
-use std::os::unix::io::AsRawFd;
+use std::{fmt::Debug, os::unix::io::AsRawFd};
 
 use crate::{
     helpers::{call_method, property},
@@ -85,6 +85,7 @@ pub enum UnregisterStatus {
 /// terminates without a call to the 'UnregisterGame' method, GameMode will
 /// automatically un-register the client. This might happen with a (small)
 /// delay.
+#[derive(Debug)]
 pub struct GameModeProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> GameModeProxy<'a> {
@@ -123,8 +124,8 @@ impl<'a> GameModeProxy<'a> {
         requester: R,
     ) -> Result<GameModeStatus, Error>
     where
-        F: AsRawFd + Type + Serialize,
-        R: AsRawFd + Type + Serialize,
+        F: AsRawFd + Type + Serialize + Debug,
+        R: AsRawFd + Type + Serialize + Debug,
     {
         call_method(&self.0, "QueryStatusByPIDFd", &(target, requester)).await
     }
@@ -170,8 +171,8 @@ impl<'a> GameModeProxy<'a> {
         requester: R,
     ) -> Result<RegisterStatus, Error>
     where
-        F: AsRawFd + Type + Serialize,
-        R: AsRawFd + Type + Serialize,
+        F: AsRawFd + Type + Serialize + Debug,
+        R: AsRawFd + Type + Serialize + Debug,
     {
         call_method(&self.0, "RegisterGameByPIDFd", &(target, requester)).await
     }
@@ -216,8 +217,8 @@ impl<'a> GameModeProxy<'a> {
         requester: R,
     ) -> Result<UnregisterStatus, Error>
     where
-        F: AsRawFd + Type + Serialize,
-        R: AsRawFd + Type + Serialize,
+        F: AsRawFd + Type + Serialize + Debug,
+        R: AsRawFd + Type + Serialize + Debug,
     {
         call_method(&self.0, "UnregisterGameByPIDFd", &(target, requester)).await
     }

--- a/src/desktop/handle_token.rs
+++ b/src/desktop/handle_token.rs
@@ -6,7 +6,7 @@ use std::{convert::TryFrom, fmt::Display};
 use zvariant_derive::Type;
 
 /// A handle token is a DBus Object Path element, specified in the
-/// `RequestProxy` or [`SessionProxy`](crate::session::SessionProxy) object path following this format
+/// `RequestProxy` or [`SessionProxy`](crate::desktop::SessionProxy) object path following this format
 /// `/org/freedesktop/portal/desktop/request/SENDER/TOKEN` where sender is the
 /// caller's unique name and token is the HandleToken.
 ///
@@ -14,7 +14,7 @@ use zvariant_derive::Type;
 /// "[A-Z][a-z][0-9]_"
 ///
 /// ```
-/// use ashpd::HandleToken;
+/// use ashpd::desktop::HandleToken;
 /// use std::convert::TryFrom;
 ///
 /// assert_eq!(HandleToken::try_from("token").is_ok(), true);

--- a/src/desktop/handle_token.rs
+++ b/src/desktop/handle_token.rs
@@ -8,21 +8,10 @@ use zvariant_derive::Type;
 /// A handle token is a DBus Object Path element, specified in the
 /// `RequestProxy` or [`SessionProxy`](crate::desktop::SessionProxy) object path following this format
 /// `/org/freedesktop/portal/desktop/request/SENDER/TOKEN` where sender is the
-/// caller's unique name and token is the HandleToken.
+/// caller's unique name and token is the [`HandleToken`].
 ///
 /// A valid object path element must only contain the ASCII characters
-/// "[A-Z][a-z][0-9]_"
-///
-/// ```
-/// use ashpd::desktop::HandleToken;
-/// use std::convert::TryFrom;
-///
-/// assert_eq!(HandleToken::try_from("token").is_ok(), true);
-///
-/// assert_eq!(HandleToken::try_from("/test").is_ok(), false);
-///
-/// assert_eq!(HandleToken::try_from("تجربة").is_ok(), false);
-/// ```
+/// `[A-Z][a-z][0-9]_`
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, Type)]
 pub struct HandleToken(String);
 
@@ -70,5 +59,20 @@ impl TryFrom<String> for HandleToken {
     type Error = HandleInvalidCharacter;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         HandleToken::try_from(value.as_str())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::HandleToken;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn handle_token() {
+        assert_eq!(HandleToken::try_from("token").is_ok(), true);
+
+        assert_eq!(HandleToken::try_from("/test").is_ok(), false);
+
+        assert_eq!(HandleToken::try_from("تجربة").is_ok(), false);
     }
 }

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -184,7 +184,7 @@ impl<'a> InhibitProxy<'a> {
         &self,
         window: WindowIdentifier,
         options: CreateMonitorOptions,
-    ) -> Result<SessionProxy<'_>, Error> {
+    ) -> Result<SessionProxy<'a>, Error> {
         let path: OwnedObjectPath = self
             .0
             .call_method("Inhibit", &(window, options))
@@ -209,7 +209,7 @@ impl<'a> InhibitProxy<'a> {
         window: WindowIdentifier,
         flags: BitFlags<InhibitFlags>,
         options: InhibitOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("Inhibit", &(window, flags, options))

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -47,9 +47,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::{ObjectPath, OwnedObjectPath};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
     helpers::{call_basic_response_method, call_method, call_request_method, property},
-    Error, HandleToken, SessionProxy, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
@@ -170,8 +171,8 @@ impl<'a> InhibitProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<InhibitProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Inhibit")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -147,6 +147,11 @@ impl<'a> InhibitProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Creates a monitoring session.
     /// While this session is active, the caller will receive `state_changed`
     /// signals with updates on the session state.

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -164,6 +164,7 @@ pub enum SessionState {
 
 /// The interface lets sandboxed applications inhibit the user session from
 /// ending, suspending, idling or getting switched away.
+#[derive(Debug)]
 pub struct InhibitProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> InhibitProxy<'a> {

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -153,6 +153,7 @@ impl<'a> InhibitProxy<'a> {
     /// # Arguments
     ///
     /// * `window` - The application window identifier.
+    #[doc(alias = "CreateMonitor")]
     pub async fn create_monitor(
         &self,
         window: WindowIdentifier,
@@ -181,7 +182,8 @@ impl<'a> InhibitProxy<'a> {
     ///
     /// * `window` - The application window identifier.
     /// * `flags` - The flags determine what changes are inhibited.
-    /// * `reason` - User-visible reason for the inhibition..
+    /// * `reason` - User-visible reason for the inhibition.
+    #[doc(alias = "Inhibit")]
     pub async fn inhibit(
         &self,
         window: WindowIdentifier,
@@ -199,6 +201,7 @@ impl<'a> InhibitProxy<'a> {
     }
 
     /// Signal emitted when the session state changes.
+    #[doc(alias = "StateChanged")]
     pub async fn receive_state_changed(&self) -> Result<InhibitState, Error> {
         let mut stream = self.0.receive_signal("StateChanged").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -212,6 +215,7 @@ impl<'a> InhibitProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
+    #[doc(alias = "QueryEndResponse")]
     pub async fn query_end_response(&self, session: &SessionProxy<'_>) -> Result<(), Error> {
         call_method(&self.0, "QueryEndResponse", &(session)).await
     }

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -96,9 +96,9 @@ struct CreateMonitor {
 #[doc(hidden)]
 struct State {
     #[zvariant(rename = "screensaver-active")]
-    pub screensaver_active: bool,
+    screensaver_active: bool,
     #[zvariant(rename = "session-state")]
-    pub session_state: SessionState,
+    session_state: SessionState,
 }
 
 #[derive(Debug, Serialize, Deserialize, Type)]
@@ -158,18 +158,18 @@ impl<'a> InhibitProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `window` - The application window identifier.
+    /// * `identifier` - The application window identifier.
     #[doc(alias = "CreateMonitor")]
     pub async fn create_monitor(
         &self,
-        window: WindowIdentifier,
+        identifier: WindowIdentifier,
     ) -> Result<SessionProxy<'a>, Error> {
         let options = CreateMonitorOptions::default();
         let monitor: CreateMonitor = call_request_method(
             &self.0,
             &options.handle_token,
             "CreateMonitor",
-            &(window, &options),
+            &(identifier, &options),
         )
         .await?;
         let proxy =
@@ -186,13 +186,13 @@ impl<'a> InhibitProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `window` - The application window identifier.
+    /// * `identifier` - The application window identifier.
     /// * `flags` - The flags determine what changes are inhibited.
     /// * `reason` - User-visible reason for the inhibition.
     #[doc(alias = "Inhibit")]
     pub async fn inhibit(
         &self,
-        window: WindowIdentifier,
+        identifier: WindowIdentifier,
         flags: BitFlags<InhibitFlags>,
         reason: &str,
     ) -> Result<(), Error> {
@@ -201,7 +201,7 @@ impl<'a> InhibitProxy<'a> {
             &self.0,
             &options.handle_token,
             "Inhibit",
-            &(window, flags, &options),
+            &(identifier, flags, &options),
         )
         .await
     }

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -132,6 +132,7 @@ pub enum SessionState {
 /// The interface lets sandboxed applications inhibit the user session from
 /// ending, suspending, idling or getting switched away.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Inhibit")]
 pub struct InhibitProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> InhibitProxy<'a> {

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -42,7 +42,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
-    helpers::{call_basic_response_method, call_method, call_request_method, property},
+    helpers::{call_basic_response_method, call_method, call_request_method},
     Error, WindowIdentifier,
 };
 
@@ -224,10 +224,5 @@ impl<'a> InhibitProxy<'a> {
     #[doc(alias = "QueryEndResponse")]
     pub async fn query_end_response(&self, session: &SessionProxy<'_>) -> Result<(), Error> {
         call_method(&self.0, "QueryEndResponse", &(session)).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -43,7 +43,7 @@
 //! }
 //! ```
 use enumflags2::BitFlags;
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::{ObjectPath, OwnedObjectPath};

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -31,7 +31,7 @@
 //!     Ok(())
 //! }
 //! ```
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::{ObjectPath, OwnedObjectPath};

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -14,11 +14,13 @@
 //!
 //!     let session = proxy.create_session(options).await?;
 //!
-//!     proxy.start(
-//!         &session,
-//!         WindowIdentifier::default(),
-//!         SessionStartOptions::default(),
-//!     ).await?;
+//!     proxy
+//!         .start(
+//!             &session,
+//!             WindowIdentifier::default(),
+//!             SessionStartOptions::default(),
+//!         )
+//!         .await?;
 //!
 //!     let location = proxy.receive_location_updated().await?;
 //!
@@ -59,7 +61,7 @@ pub enum Accuracy {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for a location access request.
+/// Specified options for a [`LocationProxy::create_session`] request.
 pub struct CreateSessionOptions {
     /// A string that will be used as the last element of the session handle.
     session_handle_token: Option<HandleToken>,
@@ -98,7 +100,7 @@ impl CreateSessionOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for a location session start request.
+/// Specified options for a [`LocationProxy::start`] request.
 pub struct SessionStartOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -189,6 +191,7 @@ struct LocationInner {
 pub struct LocationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> LocationProxy<'a> {
+    /// Create a new instance of [`LocationProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<LocationProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Location")
@@ -211,8 +214,6 @@ impl<'a> LocationProxy<'a> {
     /// # Arguments
     ///
     /// * `options` - A [`CreateSessionOptions`]
-    ///
-    /// [`CreateSessionOptions`]: ./struct.CreateSessionOptions.html
     pub async fn create_session(
         &self,
         options: CreateSessionOptions,
@@ -229,8 +230,6 @@ impl<'a> LocationProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - A `SessionStartOptions`.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -176,6 +176,7 @@ impl<'a> LocationProxy<'a> {
     }
 
     /// Signal emitted when the user location is updated.
+    #[doc(alias = "LocationUpdated")]
     pub async fn receive_location_updated(&self) -> Result<Location, Error> {
         let mut stream = self.0.receive_signal("LocationUpdated").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -189,6 +190,7 @@ impl<'a> LocationProxy<'a> {
     /// * `distance_threshold` - Sets the distance threshold in meters, default to `0`.
     /// * `time_threshold` - Sets the time threshold in seconds, default to `0`.
     /// * `accuracy` - Sets the location accuracy, default to [`Accuracy::Exact`].
+    #[doc(alias = "CreateSession")]
     pub async fn create_session(
         &self,
         distance_threshold: Option<u32>,
@@ -220,6 +222,7 @@ impl<'a> LocationProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - Identifier for the application window.
+    #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -161,6 +161,7 @@ struct LocationInner {
 /// The interface lets sandboxed applications query basic information about the
 /// location.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Location")]
 pub struct LocationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> LocationProxy<'a> {

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -176,6 +176,11 @@ impl<'a> LocationProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Signal emitted when the user location is updated.
     #[doc(alias = "LocationUpdated")]
     pub async fn receive_location_updated(&self) -> Result<Location, Error> {

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -214,7 +214,7 @@ impl<'a> LocationProxy<'a> {
     pub async fn create_session(
         &self,
         options: CreateSessionOptions,
-    ) -> Result<SessionProxy<'_>, Error> {
+    ) -> Result<SessionProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("CreateSession", &(options))
@@ -238,7 +238,7 @@ impl<'a> LocationProxy<'a> {
         session: &SessionProxy<'_>,
         parent_window: WindowIdentifier,
         options: SessionStartOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("Start", &(session, parent_window, options))

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -188,6 +188,7 @@ struct LocationInner {
 
 /// The interface lets sandboxed applications query basic information about the
 /// location.
+#[derive(Debug)]
 pub struct LocationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> LocationProxy<'a> {

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -29,7 +29,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
-    helpers::{call_basic_response_method, call_method, property},
+    helpers::{call_basic_response_method, call_method},
     Error, WindowIdentifier,
 };
 
@@ -242,10 +242,5 @@ impl<'a> LocationProxy<'a> {
             &(session, parent_window, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -35,9 +35,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::{ObjectPath, OwnedObjectPath};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
     helpers::{call_basic_response_method, call_method, property},
-    Error, HandleToken, SessionProxy, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Type)]
@@ -194,8 +195,8 @@ impl<'a> LocationProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<LocationProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Location")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -227,19 +227,19 @@ impl<'a> LocationProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
     ) -> Result<(), Error> {
         let options = SessionStartOptions::default();
         call_basic_response_method(
             &self.0,
             &options.handle_token,
             "Start",
-            &(session, parent_window, &options),
+            &(session, identifier, &options),
         )
         .await
     }

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -15,7 +15,7 @@
 //! ```
 
 use crate::{helpers::property, Error};
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 
 /// The interface provides information about low system memory to sandboxed
 /// applications. It is not a portal in the strict sense, since it does not

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -42,6 +42,7 @@ impl<'a> MemoryMonitorProxy<'a> {
     /// Signal emitted when a particular low memory situation happens
     /// with 0 being the lowest level of memory availability warning, and 255
     /// being the highest.
+    #[doc(alias = "LowMemoryWarning")]
     pub async fn receive_low_memory_warning(&self) -> Result<i32, Error> {
         let mut stream = self.0.receive_signal("LowMemoryWarning").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -23,6 +23,7 @@ use futures_lite::StreamExt;
 pub struct MemoryMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> MemoryMonitorProxy<'a> {
+    /// Create a new instance of [`MemoryMonitorProxy`].
     pub async fn new(
         connection: &zbus::azync::Connection,
     ) -> Result<MemoryMonitorProxy<'a>, Error> {

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -14,7 +14,7 @@
 //! }
 //! ```
 
-use crate::Error;
+use crate::{helpers::property, Error};
 use futures_lite::StreamExt;
 
 /// The interface provides information about low system memory to sandboxed
@@ -46,9 +46,6 @@ impl<'a> MemoryMonitorProxy<'a> {
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -23,6 +23,7 @@ use super::{DESTINATION, PATH};
 /// applications. It is not a portal in the strict sense, since it does not
 /// involve user interaction.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.MemoryMonitor")]
 pub struct MemoryMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> MemoryMonitorProxy<'a> {

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -14,7 +14,7 @@
 //! }
 //! ```
 
-use crate::{helpers::property, Error};
+use crate::Error;
 use futures::prelude::stream::*;
 
 use super::{DESTINATION, PATH};
@@ -53,10 +53,5 @@ impl<'a> MemoryMonitorProxy<'a> {
         let mut stream = self.0.receive_signal("LowMemoryWarning").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
         message.body::<i32>().map_err(From::from)
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -2,36 +2,53 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::memory_monitor::MemoryMonitorProxy;
-//! use zbus::{self, fdo::Result};
 //!
-//! fn main() -> Result<()> {
-//!     let connection = zbus::Connection::new_session()?;
-//!     let proxy = MemoryMonitorProxy::new(&connection);
-//!     proxy.connect_low_memory_warning(move |level| {
-//!         println!("{:#?}", level);
-//!         Ok(())
-//!     })?;
+//! async fn run() -> Result<(), ashpd::Error> {
+//!     let connection = zbus::azync::Connection::new_session().await?;
+//!     let proxy = MemoryMonitorProxy::new(&connection).await?;
+//!
+//!     let level = proxy.receive_low_memory_warning().await?;
+//!     println!("{:#?}", level);
+//!
 //!     Ok(())
 //! }
 //! ```
-use zbus::{dbus_proxy, fdo::Result};
 
-#[dbus_proxy(
-    interface = "org.freedesktop.portal.MemoryMonitor",
-    default_service = "org.freedesktop.portal.Desktop",
-    default_path = "/org/freedesktop/portal/desktop"
-)]
+use crate::Error;
+use futures_lite::StreamExt;
+
 /// The interface provides information about low system memory to sandboxed
 /// applications. It is not a portal in the strict sense, since it does not
 /// involve user interaction.
-trait MemoryMonitor {
-    #[dbus_proxy(signal)]
+pub struct MemoryMonitorProxy<'a>(zbus::azync::Proxy<'a>);
+
+impl<'a> MemoryMonitorProxy<'a> {
+    pub async fn new(
+        connection: &zbus::azync::Connection,
+    ) -> Result<MemoryMonitorProxy<'a>, Error> {
+        let proxy = zbus::ProxyBuilder::new_bare(connection)
+            .interface("org.freedesktop.portal.MemoryMonitor")
+            .path("/org/freedesktop/portal/desktop")?
+            .destination("org.freedesktop.portal.Desktop")
+            .build_async()
+            .await?;
+        Ok(Self(proxy))
+    }
+
     /// Signal emitted when a particular low memory situation happens
     /// with 0 being the lowest level of memory availability warning, and 255
     /// being the highest.
-    fn low_memory_warning(&self, level: i32) -> Result<()>;
+    pub async fn receive_low_memory_warning(&self) -> Result<i32, Error> {
+        let mut stream = self.0.receive_signal("LowMemoryWarning").await?;
+        let message = stream.next().await.ok_or(Error::NoResponse)?;
+        message.body::<i32>().map_err(From::from)
+    }
 
     /// The version of this DBus interface.
-    #[dbus_proxy(property, name = "version")]
-    fn version(&self) -> Result<u32>;
+    pub async fn version(&self) -> Result<u32, Error> {
+        self.0
+            .get_property::<u32>("version")
+            .await
+            .map_err(From::from)
+    }
 }

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -20,6 +20,7 @@ use futures::prelude::stream::*;
 /// The interface provides information about low system memory to sandboxed
 /// applications. It is not a portal in the strict sense, since it does not
 /// involve user interaction.
+#[derive(Debug)]
 pub struct MemoryMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> MemoryMonitorProxy<'a> {

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -40,6 +40,11 @@ impl<'a> MemoryMonitorProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Signal emitted when a particular low memory situation happens
     /// with 0 being the lowest level of memory availability warning, and 255
     /// being the highest.

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -17,6 +17,8 @@
 use crate::{helpers::property, Error};
 use futures::prelude::stream::*;
 
+use super::{DESTINATION, PATH};
+
 /// The interface provides information about low system memory to sandboxed
 /// applications. It is not a portal in the strict sense, since it does not
 /// involve user interaction.
@@ -30,8 +32,8 @@ impl<'a> MemoryMonitorProxy<'a> {
     ) -> Result<MemoryMonitorProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.MemoryMonitor")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -4,7 +4,7 @@ pub(crate) const PATH: &str = "/org/freedesktop/portal/desktop";
 mod handle_token;
 pub(crate) mod request;
 mod session;
-pub use self::handle_token::HandleToken;
+pub(crate) use self::handle_token::HandleToken;
 pub use self::request::ResponseError;
 pub use self::session::SessionProxy;
 

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,3 +1,13 @@
+pub(crate) const DESTINATION: &str = "org.freedesktop.portal.Desktop";
+pub(crate) const PATH: &str = "/org/freedesktop/portal/desktop";
+
+mod handle_token;
+pub(crate) mod request;
+mod session;
+pub use self::handle_token::HandleToken;
+pub use self::request::ResponseError;
+pub use self::session::SessionProxy;
+
 /// Request access to the current logged user information such as the id, name
 /// or their avatar uri.
 pub mod account;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,45 +1,65 @@
 /// Request access to the current logged user information such as the id, name
 /// or their avatar uri.
 pub mod account;
+
 /// Request running an application in the background.
 pub mod background;
+
 /// Check if a camera is available, request access to it and open a PipeWire
 /// remote stream.
 pub mod camera;
+
 /// Request access to specific devices such as camera, speakers or microphone.
 pub mod device;
+
 /// Compose an email.
 pub mod email;
+
 /// Open/save file(s) chooser.
 pub mod file_chooser;
+
 /// Enable/disable/query the status of Game Mode.
 pub mod game_mode;
+
 /// Inhibit the session from being restarted or the user from logging out.
 pub mod inhibit;
+
 /// Query the user's GPS location.
 pub mod location;
+
 /// Monitor memory level.
 pub mod memory_monitor;
+
 /// Check the status of the network on a user's machine.
 pub mod network_monitor;
+
 /// Send/withdraw notifications.
 pub mod notification;
+
 /// Open a file or a directory.
 pub mod open_uri;
-/// Print a docucment.
+
+/// Print a document.
 pub mod print;
+
 /// Start a remote desktop session and interact with it.
 pub mod remote_desktop;
+
 /// Start a screencast session and get the PipeWire remote of it.
 pub mod screencast;
+
 /// Take a screenshot or pick a color.
 pub mod screenshot;
+
 /// Retrieve a per-application secret used to encrypt confidential data inside
 /// the sandbox.
 pub mod secret;
+
 /// Read & listen to system settings changes.
 pub mod settings;
+
 /// Move a file to the trash.
 pub mod trash;
+
 /// Set a wallpaper on lockscreen, background or both.
 pub mod wallpaper;

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -10,13 +10,13 @@
 //!
 //!     println!("{}", proxy.can_reach("www.google.com", 80).await?);
 //!
-//!     println!("{}", proxy.get_available().await?);
+//!     println!("{}", proxy.is_available().await?);
 //!
-//!     println!("{:#?}", proxy.get_connectivity().await?);
+//!     println!("{:#?}", proxy.connectivity().await?);
 //!
-//!     println!("{}", proxy.get_metered().await?);
+//!     println!("{}", proxy.is_metered().await?);
 //!
-//!     println!("{:#?}", proxy.get_status().await?);
+//!     println!("{:#?}", proxy.status().await?);
 //!
 //!     Ok(())
 //! }
@@ -95,6 +95,7 @@ impl<'a> NetworkMonitorProxy<'a> {
     ///
     /// * `hostname` - The hostname to reach.
     /// * `port` - The port to reach.
+    #[doc(alias = "CanReach")]
     pub async fn can_reach(&self, hostname: &str, port: u32) -> Result<bool, Error> {
         call_method(&self.0, "CanReach", &(hostname, port)).await
     }
@@ -102,24 +103,32 @@ impl<'a> NetworkMonitorProxy<'a> {
     /// Returns whether the network is considered available.
     /// That is, whether the system as a default route for at least one of IPv4
     /// or IPv6.
-    pub async fn get_available(&self) -> Result<bool, Error> {
+    #[doc(alias = "GetAvailable")]
+    #[doc(alias = "get_available")]
+    pub async fn is_available(&self) -> Result<bool, Error> {
         call_method(&self.0, "GetAvailable", &()).await
     }
 
     /// Returns more detailed information about the host's network connectivity
-    pub async fn get_connectivity(&self) -> Result<Connectivity, Error> {
+    #[doc(alias = "GetConnectivity")]
+    #[doc(alias = "get_connectivity")]
+    pub async fn connectivity(&self) -> Result<Connectivity, Error> {
         call_method(&self.0, "GetConnectivity", &()).await
     }
 
     /// Returns whether the network is considered metered.
     /// That is, whether the system as traffic flowing through the default
     /// connection that is subject to limitations by service providers.
-    pub async fn get_metered(&self) -> Result<bool, Error> {
+    #[doc(alias = "GetMetered")]
+    #[doc(alias = "get_metered")]
+    pub async fn is_metered(&self) -> Result<bool, Error> {
         call_method(&self.0, "GetMetered", &()).await
     }
 
     /// Returns the three values all at once.
-    pub async fn get_status(&self) -> Result<NetworkStatus, Error> {
+    #[doc(alias = "GetStatus")]
+    #[doc(alias = "get_status")]
+    pub async fn status(&self) -> Result<NetworkStatus, Error> {
         call_method(&self.0, "GetStatus", &()).await
     }
 

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -1,3 +1,4 @@
+//! **Note** this portal doesn't work for sandboxed applications.
 //! # Examples
 //!
 //! ```rust,no_run

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -20,7 +20,10 @@
 //!     Ok(())
 //! }
 //! ```
-use crate::Error;
+use crate::{
+    helpers::{call_method, property},
+    Error,
+};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
@@ -88,58 +91,35 @@ impl<'a> NetworkMonitorProxy<'a> {
     /// * `hostname` - The hostname to reach.
     /// * `port` - The port to reach.
     pub async fn can_reach(&self, hostname: &str, port: u32) -> Result<bool, Error> {
-        self.0
-            .call_method("CanReach", &(hostname, port))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "CanReach", &(hostname, port)).await
     }
 
     /// Returns whether the network is considered available.
     /// That is, whether the system as a default route for at least one of IPv4
     /// or IPv6.
     pub async fn get_available(&self) -> Result<bool, Error> {
-        self.0
-            .call_method("GetAvailable", &())
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "GetAvailable", &()).await
     }
 
     /// Returns more detailed information about the host's network connectivity
     pub async fn get_connectivity(&self) -> Result<Connectivity, Error> {
-        self.0
-            .call_method("GetConnectivity", &())
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "GetConnectivity", &()).await
     }
 
     /// Returns whether the network is considered metered.
     /// That is, whether the system as traffic flowing through the default
     /// connection that is subject to limitations by service providers.
     pub async fn get_metered(&self) -> Result<bool, Error> {
-        self.0
-            .call_method("GetMetered", &())
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "GetMetered", &()).await
     }
 
     /// Returns the three values all at once.
     pub async fn get_status(&self) -> Result<NetworkStatus, Error> {
-        self.0
-            .call_method("GetStatus", &())
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "GetStatus", &()).await
     }
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -28,6 +28,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{DESTINATION, PATH};
+
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
 /// The network status, composed of the availability, metered & connectivity
 pub struct NetworkStatus {
@@ -79,8 +81,8 @@ impl<'a> NetworkMonitorProxy<'a> {
     ) -> Result<NetworkMonitorProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.NetworkMonitor")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -90,6 +90,11 @@ impl<'a> NetworkMonitorProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Returns whether the given hostname is believed to be reachable.
     ///
     /// # Arguments

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -72,6 +72,7 @@ impl fmt::Display for Connectivity {
 pub struct NetworkMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NetworkMonitorProxy<'a> {
+    /// Create a new instance of [`NetworkMonitorProxy`].
     pub async fn new(
         connection: &zbus::azync::Connection,
     ) -> Result<NetworkMonitorProxy<'a>, Error> {

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -69,6 +69,7 @@ impl fmt::Display for Connectivity {
 /// It is not a portal in the strict sense, since it does not involve user
 /// interaction. Applications are expected to use this interface indirectly,
 /// via a library API such as the GLib `GNetworkMonitor` interface.
+#[derive(Debug)]
 pub struct NetworkMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NetworkMonitorProxy<'a> {

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -21,10 +21,7 @@
 //!     Ok(())
 //! }
 //! ```
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
@@ -136,10 +133,5 @@ impl<'a> NetworkMonitorProxy<'a> {
     #[doc(alias = "get_status")]
     pub async fn status(&self) -> Result<NetworkStatus, Error> {
         call_method(&self.0, "GetStatus", &()).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -73,6 +73,7 @@ impl fmt::Display for Connectivity {
 /// interaction. Applications are expected to use this interface indirectly,
 /// via a library API such as the GLib `GNetworkMonitor` interface.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.NetworkMonitor")]
 pub struct NetworkMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NetworkMonitorProxy<'a> {

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -50,6 +50,8 @@ use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
 use zvariant::{OwnedValue, Signature};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{DESTINATION, PATH};
+
 #[derive(
     Debug, Clone, Deserialize, AsRefStr, EnumString, IntoStaticStr, ToString, PartialEq, Eq,
 )]
@@ -243,8 +245,8 @@ impl<'a> NotificationProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<NotificationProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Notification")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -44,7 +44,7 @@ use crate::{
     helpers::{call_method, property},
     Error,
 };
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{self, Deserialize, Serialize, Serializer};
 use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
 use zvariant::{OwnedValue, Signature};

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -40,10 +40,7 @@
 //! }
 //! ```
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use futures::prelude::stream::*;
 use serde::{self, Deserialize, Serialize, Serializer};
 use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
@@ -293,10 +290,5 @@ impl<'a> NotificationProxy<'a> {
     #[doc(alias = "RemoveNotification")]
     pub async fn remove_notification(&self, id: &str) -> Result<(), Error> {
         call_method(&self.0, "RemoveNotification", &(id)).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -10,16 +10,18 @@
 //!     let proxy = NotificationProxy::new(&connection).await?;
 //!
 //!     let notification_id = "org.gnome.design.Contrast";
-//!     proxy.add_notification(
-//!         notification_id,
-//!         Notification::new("Contrast")
-//!             .default_action("open")
-//!             .default_action_target(Value::U32(100).into())
-//!             .body("color copied to clipboard")
-//!             .priority(Priority::High)
-//!             .button(Button::new("Copy", "copy").target(Value::U32(32).into()))
-//!             .button(Button::new("Delete", "delete").target(Value::U32(40).into())),
-//!     ).await?;
+//!     proxy
+//!         .add_notification(
+//!             notification_id,
+//!             Notification::new("Contrast")
+//!                 .default_action("open")
+//!                 .default_action_target(Value::U32(100).into())
+//!                 .body("color copied to clipboard")
+//!                 .priority(Priority::High)
+//!                 .button(Button::new("Copy", "copy").target(Value::U32(32).into()))
+//!                 .button(Button::new("Delete", "delete").target(Value::U32(40).into())),
+//!         )
+//!         .await?;
 //!
 //!     let action = proxy.receive_action_invoked().await?;
 //!     match action.name() {
@@ -236,6 +238,7 @@ impl Action {
 pub struct NotificationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NotificationProxy<'a> {
+    /// Create a new instance of [`NotificationProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<NotificationProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Notification")

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -235,6 +235,7 @@ impl Action {
 /// interface. Other actions are activated by sending the
 ///  `#org.freedeskop.portal.Notification::ActionInvoked` signal to the
 /// application.
+#[derive(Debug)]
 pub struct NotificationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NotificationProxy<'a> {

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -253,6 +253,7 @@ impl<'a> NotificationProxy<'a> {
     }
 
     /// Signal emitted when a particular action is invoked.
+    #[doc(alias = "ActionInvoked")]
     pub async fn receive_action_invoked(&self) -> Result<Action, Error> {
         let mut stream = self.0.receive_signal("ActionInvoked").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -269,6 +270,7 @@ impl<'a> NotificationProxy<'a> {
     ///
     /// * `id` - Application-provided ID for this notification.
     /// * `notification` - The notification.
+    #[doc(alias = "AddNotification")]
     pub async fn add_notification(
         &self,
         id: &str,
@@ -282,6 +284,7 @@ impl<'a> NotificationProxy<'a> {
     /// # Arguments
     ///
     /// * `id` - Application-provided ID for this notification.
+    #[doc(alias = "RemoveNotification")]
     pub async fn remove_notification(&self, id: &str) -> Result<(), Error> {
         call_method(&self.0, "RemoveNotification", &(id)).await
     }

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -38,7 +38,10 @@
 //! }
 //! ```
 
-use crate::Error;
+use crate::{
+    helpers::{call_method, property},
+    Error,
+};
 use futures_lite::StreamExt;
 use serde::{self, Deserialize, Serialize, Serializer};
 use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
@@ -265,11 +268,7 @@ impl<'a> NotificationProxy<'a> {
         id: &str,
         notification: Notification,
     ) -> Result<(), Error> {
-        self.0
-            .call_method("AddNotification", &(id, notification))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "AddNotification", &(id, notification)).await
     }
 
     /// Withdraws a notification.
@@ -278,18 +277,11 @@ impl<'a> NotificationProxy<'a> {
     ///
     /// * `id` - Application-provided ID for this notification.
     pub async fn remove_notification(&self, id: &str) -> Result<(), Error> {
-        self.0
-            .call_method("RemoveNotification", &(id))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "RemoveNotification", &(id)).await
     }
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -238,6 +238,7 @@ impl Action {
 ///  `#org.freedeskop.portal.Notification::ActionInvoked` signal to the
 /// application.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Notification")]
 pub struct NotificationProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> NotificationProxy<'a> {

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -253,6 +253,11 @@ impl<'a> NotificationProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Signal emitted when a particular action is invoked.
     #[doc(alias = "ActionInvoked")]
     pub async fn receive_action_invoked(&self) -> Result<Action, Error> {

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -67,13 +67,13 @@ use crate::{
 /// Specified options for a [`OpenURIProxy::open_directory`] request.
 pub struct OpenDirOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
 }
 
 impl OpenDirOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -82,7 +82,7 @@ impl OpenDirOptions {
 /// Specified options for a [`OpenURIProxy::open_file`] or [`OpenURIProxy::open_uri`] request.
 pub struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Whether to allow the chosen application to write to the file.
     /// This key only takes effect the uri points to a local file that is
     /// exported in the document portal, and the chosen application is sandboxed
@@ -96,7 +96,7 @@ pub struct OpenFileOptions {
 impl OpenFileOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -149,8 +149,9 @@ impl<'a> OpenURIProxy<'a> {
     {
         call_basic_response_method(
             &self.0,
+            &options.handle_token,
             "OpenDirectory",
-            &(parent_window, directory.as_raw_fd(), options),
+            &(parent_window, directory.as_raw_fd(), &options),
         )
         .await
     }
@@ -173,8 +174,9 @@ impl<'a> OpenURIProxy<'a> {
     {
         call_basic_response_method(
             &self.0,
+            &options.handle_token,
             "OpenFile",
-            &(parent_window, file.as_raw_fd(), options),
+            &(parent_window, file.as_raw_fd(), &options),
         )
         .await
     }
@@ -192,7 +194,13 @@ impl<'a> OpenURIProxy<'a> {
         uri: &str,
         options: OpenFileOptions,
     ) -> Result<(), Error> {
-        call_basic_response_method(&self.0, "OpenURI", &(parent_window, uri, options)).await
+        call_basic_response_method(
+            &self.0,
+            &options.handle_token,
+            "OpenURI",
+            &(parent_window, uri, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -110,6 +110,11 @@ impl<'a> OpenURIProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Asks to open the directory containing a local file in the file browser.
     ///
     /// # Arguments

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -121,7 +121,7 @@ impl<'a> OpenURIProxy<'a> {
         parent_window: WindowIdentifier,
         directory: F,
         options: OpenDirOptions,
-    ) -> Result<RequestProxy<'_>, Error>
+    ) -> Result<RequestProxy<'a>, Error>
     where
         F: AsRawFd + Serialize + Type,
     {
@@ -150,7 +150,7 @@ impl<'a> OpenURIProxy<'a> {
         parent_window: WindowIdentifier,
         file: F,
         options: OpenFileOptions,
-    ) -> Result<RequestProxy<'_>, Error>
+    ) -> Result<RequestProxy<'a>, Error>
     where
         F: AsRawFd + Serialize + Type,
     {
@@ -176,7 +176,7 @@ impl<'a> OpenURIProxy<'a> {
         parent_window: WindowIdentifier,
         uri: &str,
         options: OpenFileOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("OpenURI", &(parent_window, uri, options))

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -116,6 +116,7 @@ impl OpenFileOptions {
 /// The interface lets sandboxed applications open URIs
 /// (e.g. a http: link to the applications homepage) under the control of the
 /// user.
+#[derive(Debug)]
 pub struct OpenURIProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> OpenURIProxy<'a> {

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -115,6 +115,7 @@ impl<'a> OpenURIProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `directory` - File descriptor for a file.
+    #[doc(alias = "OpenDirectory")]
     pub async fn open_directory<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -141,6 +142,7 @@ impl<'a> OpenURIProxy<'a> {
     /// * `file` - File descriptor for the file to open.
     /// * `writeable` - Whether the file should be writeable or not.
     /// * `ask` - Whether to always ask the user which application to use or not.
+    #[doc(alias = "OpenFile")]
     pub async fn open_file<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -169,6 +171,7 @@ impl<'a> OpenURIProxy<'a> {
     /// * `uri` - The uri to open.
     /// * `writeable` - Whether the file should be writeable or not.
     /// * `ask` - Whether to always ask the user which application to use or not.
+    #[doc(alias = "OpenURI")]
     pub async fn open_uri(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -60,8 +60,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     helpers::{call_basic_response_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
+
+use super::{HandleToken, DESTINATION, PATH};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
 /// Specified options for a [`OpenURIProxy::open_directory`] request.
@@ -124,8 +126,8 @@ impl<'a> OpenURIProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<OpenURIProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.OpenURI")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -116,12 +116,12 @@ impl<'a> OpenURIProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `directory` - File descriptor for a file.
     #[doc(alias = "OpenDirectory")]
     pub async fn open_directory<F>(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         directory: F,
     ) -> Result<(), Error>
     where
@@ -132,7 +132,7 @@ impl<'a> OpenURIProxy<'a> {
             &self.0,
             &options.handle_token,
             "OpenDirectory",
-            &(parent_window, directory.as_raw_fd(), &options),
+            &(identifier, directory.as_raw_fd(), &options),
         )
         .await
     }
@@ -141,14 +141,14 @@ impl<'a> OpenURIProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `file` - File descriptor for the file to open.
     /// * `writeable` - Whether the file should be writeable or not.
     /// * `ask` - Whether to always ask the user which application to use or not.
     #[doc(alias = "OpenFile")]
     pub async fn open_file<F>(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         file: F,
         writeable: bool,
         ask: bool,
@@ -161,7 +161,7 @@ impl<'a> OpenURIProxy<'a> {
             &self.0,
             &options.handle_token,
             "OpenFile",
-            &(parent_window, file.as_raw_fd(), &options),
+            &(identifier, file.as_raw_fd(), &options),
         )
         .await
     }
@@ -170,14 +170,14 @@ impl<'a> OpenURIProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `uri` - The uri to open.
     /// * `writeable` - Whether the file should be writeable or not.
     /// * `ask` - Whether to always ask the user which application to use or not.
     #[doc(alias = "OpenURI")]
     pub async fn open_uri(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         uri: &str,
         writeable: bool,
         ask: bool,
@@ -187,7 +187,7 @@ impl<'a> OpenURIProxy<'a> {
             &self.0,
             &options.handle_token,
             "OpenURI",
-            &(parent_window, uri, &options),
+            &(identifier, uri, &options),
         )
         .await
     }

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -1,12 +1,15 @@
 //! # Examples
 //!
-//! Open a file
+//! ## Open a file
 //!
 //! ```rust,no_run
+//! use ashpd::{
+//!     desktop::open_uri::{OpenFileOptions, OpenURIProxy},
+//!     WindowIdentifier,
+//! };
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
 //! use zvariant::Fd;
-//! use ashpd::{desktop::open_uri::{OpenFileOptions, OpenURIProxy}, WindowIdentifier};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
@@ -15,25 +18,36 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = OpenURIProxy::new(&connection).await?;
 //!
-//!     proxy.open_file(identifier, Fd::from(file.as_raw_fd()), OpenFileOptions::default().writeable(false).ask(true)).await?;
+//!     proxy
+//!         .open_file(
+//!             identifier,
+//!             Fd::from(file.as_raw_fd()),
+//!             OpenFileOptions::default().writeable(false).ask(true),
+//!         )
+//!         .await?;
 //!     Ok(())
 //! }
 //! ```
 //!
-//! Open a file from a URI
+//! ## Open a file from a URI
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::open_uri::{OpenFileOptions, OpenURIProxy}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::open_uri::{OpenFileOptions, OpenURIProxy},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = OpenURIProxy::new(&connection).await?;
 //!
-//!     proxy.open_uri(
-//!         WindowIdentifier::default(),
-//!         "file:///home/bilelmoussaoui/Downloads/adwaita-night.jpg",
-//!         OpenFileOptions::default().writeable(false).ask(true),
-//!     ).await?;
+//!     proxy
+//!         .open_uri(
+//!             WindowIdentifier::default(),
+//!             "file:///home/bilelmoussaoui/Downloads/adwaita-night.jpg",
+//!             OpenFileOptions::default().writeable(false).ask(true),
+//!         )
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -50,7 +64,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for an open directory request.
+/// Specified options for a [`OpenURIProxy::open_directory`] request.
 pub struct OpenDirOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -65,7 +79,7 @@ impl OpenDirOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options for an open file request.
+/// Specified options for a [`OpenURIProxy::open_file`] or [`OpenURIProxy::open_uri`] request.
 pub struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -105,6 +119,7 @@ impl OpenFileOptions {
 pub struct OpenURIProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> OpenURIProxy<'a> {
+    /// Create a new instance of [`OpenURIProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<OpenURIProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.OpenURI")
@@ -122,8 +137,6 @@ impl<'a> OpenURIProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `directory` - File descriptor for a file.
     /// * `options` - [`OpenDirOptions`].
-    ///
-    /// [`OpenDirOptions`]: ./struct.OpenDirOptions.html
     pub async fn open_directory<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -148,8 +161,6 @@ impl<'a> OpenURIProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `file` - File descriptor for the file to open.
     /// * `options` - [`OpenFileOptions`].
-    ///
-    /// [`OpenFileOptions`]: ./struct.OpenFileOptions.html
     pub async fn open_file<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -174,8 +185,6 @@ impl<'a> OpenURIProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `uri` - The uri to open.
     /// * `options` - [`OpenFileOptions`].
-    ///
-    /// [`OpenFileOptions`]: ./struct.OpenFileOptions.html
     pub async fn open_uri(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -95,6 +95,7 @@ impl OpenFileOptions {
 /// (e.g. a http: link to the applications homepage) under the control of the
 /// user.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.OpenURI")]
 pub struct OpenURIProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> OpenURIProxy<'a> {

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -48,10 +48,7 @@ use serde::Serialize;
 use zvariant::Type;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
-use crate::{
-    helpers::{call_basic_response_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_basic_response_method, Error, WindowIdentifier};
 
 use super::{HandleToken, DESTINATION, PATH};
 
@@ -193,10 +190,5 @@ impl<'a> OpenURIProxy<'a> {
             &(parent_window, uri, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::print::{PrintOptions, PrintProxy};
-//! use ashpd::{WindowIdentifier};
+//! use ashpd::WindowIdentifier;
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
 //! use zvariant::Fd;
@@ -21,8 +21,8 @@
 //!             "test",
 //!             Fd::from(file.as_raw_fd()),
 //!             PrintOptions::default(),
-//!         ).await?;
-//!
+//!         )
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -445,7 +445,7 @@ impl PageSetup {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a prepare print request.
+/// Specified options for a [`PrintProxy::prepare_print`] request.
 pub struct PreparePrintOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -468,18 +468,18 @@ impl PreparePrintOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a print request.
+/// Specified options for a [`PrintProxy::print`] request.
 pub struct PrintOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
     /// Whether to make the dialog modal.
     modal: Option<bool>,
-    /// Token that was returned by a previous `prepare_print` call.
+    /// Token that was returned by a previous [`PrintProxy::prepare_print`] call.
     token: Option<String>,
 }
 
 impl PrintOptions {
-    /// A token retrieved from a prepare print response.
+    /// A token retrieved from [`PrintProxy::prepare_print`].
     pub fn token(mut self, token: &str) -> Self {
         self.token = Some(token.to_string());
         self
@@ -499,7 +499,7 @@ impl PrintOptions {
 }
 
 #[derive(DeserializeDict, SerializeDict, TypeDict, Debug)]
-/// A response returned by a prepare print request.
+/// A response to a [`PrintProxy::prepare_print`] request.
 pub struct PreparePrint {
     /// The printing settings.
     pub settings: Settings,
@@ -514,6 +514,7 @@ pub struct PreparePrint {
 pub struct PrintProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> PrintProxy<'a> {
+    /// Create a new instance of [`PrintProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<PrintProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Print")
@@ -534,10 +535,6 @@ impl<'a> PrintProxy<'a> {
     /// * `settings` - [`Settings`].
     /// * `page_setup` - [`PageSetup`].
     /// * `options` - [`PreparePrintOptions`].
-    ///
-    /// [`Settings`]: ./struct.Settings.html
-    /// [`PageSetup`]: ./struct.PageSetup.html
-    /// [`PreparePrintOptions`]: ./struct.PreparePrintOptions.html
     pub async fn prepare_print(
         &self,
         parent_window: WindowIdentifier,
@@ -565,8 +562,6 @@ impl<'a> PrintProxy<'a> {
     /// * `title` - The title for the print dialog.
     /// * `fd` - File descriptor for reading the content to print.
     /// * `options` - [`PrintOptions`].
-    ///
-    /// [`PrintOptions`]: ./struct.PrintOptions.html
     pub async fn print<F>(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -448,7 +448,7 @@ impl PageSetup {
 /// Specified options for a [`PrintProxy::prepare_print`] request.
 pub struct PreparePrintOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Whether to make the dialog modal.
     modal: Option<bool>,
 }
@@ -456,7 +456,7 @@ pub struct PreparePrintOptions {
 impl PreparePrintOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -471,7 +471,7 @@ impl PreparePrintOptions {
 /// Specified options for a [`PrintProxy::print`] request.
 pub struct PrintOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Whether to make the dialog modal.
     modal: Option<bool>,
     /// Token that was returned by a previous [`PrintProxy::prepare_print`] call.
@@ -493,7 +493,7 @@ impl PrintOptions {
 
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -546,8 +546,9 @@ impl<'a> PrintProxy<'a> {
     ) -> Result<PreparePrint, Error> {
         call_request_method(
             &self.0,
+            &options.handle_token,
             "PreparePint",
-            &(parent_window, title, settings, page_setup, options),
+            &(parent_window, title, settings, page_setup, &options),
         )
         .await
     }
@@ -575,8 +576,9 @@ impl<'a> PrintProxy<'a> {
     {
         call_basic_response_method(
             &self.0,
+            &options.handle_token,
             "Print",
-            &(parent_window, title, fd.as_raw_fd(), options),
+            &(parent_window, title, fd.as_raw_fd(), &options),
         )
         .await
     }

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -508,6 +508,7 @@ pub struct PreparePrint {
 
 /// The interface lets sandboxed applications print.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Print")]
 pub struct PrintProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> PrintProxy<'a> {

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -532,6 +532,7 @@ impl<'a> PrintProxy<'a> {
     /// * `settings` - [`Settings`].
     /// * `page_setup` - [`PageSetup`].
     /// * `modal` - Whether the dialog should be a modal.
+    #[doc(alias = "PreparePint")]
     pub async fn prepare_print(
         &self,
         parent_window: WindowIdentifier,
@@ -562,6 +563,7 @@ impl<'a> PrintProxy<'a> {
     /// * `fd` - File descriptor for reading the content to print.
     /// * `token` - A token returned by a call to [`PrintProxy::prepare_print`].
     /// * `modal` - Whether the dialog should be a modal.
+    #[doc(alias = "Print")]
     pub async fn print<F>(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -533,7 +533,7 @@ impl<'a> PrintProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `title` - Title for the print dialog.
     /// * `settings` - [`Settings`].
     /// * `page_setup` - [`PageSetup`].
@@ -541,7 +541,7 @@ impl<'a> PrintProxy<'a> {
     #[doc(alias = "PreparePint")]
     pub async fn prepare_print(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         title: &str,
         settings: Settings,
         page_setup: PageSetup,
@@ -552,7 +552,7 @@ impl<'a> PrintProxy<'a> {
             &self.0,
             &options.handle_token,
             "PreparePint",
-            &(parent_window, title, settings, page_setup, &options),
+            &(identifier, title, settings, page_setup, &options),
         )
         .await
     }
@@ -564,7 +564,7 @@ impl<'a> PrintProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - The application window identifier.
+    /// * `identifier` - The application window identifier.
     /// * `title` - The title for the print dialog.
     /// * `fd` - File descriptor for reading the content to print.
     /// * `token` - A token returned by a call to [`PrintProxy::prepare_print`].
@@ -572,7 +572,7 @@ impl<'a> PrintProxy<'a> {
     #[doc(alias = "Print")]
     pub async fn print<F>(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         title: &str,
         fd: F,
         token: &str,
@@ -586,7 +586,7 @@ impl<'a> PrintProxy<'a> {
             &self.0,
             &options.handle_token,
             "Print",
-            &(parent_window, title, fd.as_raw_fd(), &options),
+            &(identifier, title, fd.as_raw_fd(), &options),
         )
         .await
     }

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -523,6 +523,11 @@ impl<'a> PrintProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Presents a print dialog to the user and returns print settings and page
     /// setup.
     ///

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -35,9 +35,10 @@ use strum_macros::{AsRefStr, EnumString, IntoStaticStr, ToString};
 use zvariant::Signature;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
+use super::{HandleToken, DESTINATION, PATH};
 use crate::{
     helpers::{call_basic_response_method, call_request_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(
@@ -519,8 +520,8 @@ impl<'a> PrintProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<PrintProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Print")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -44,7 +44,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use super::{HandleToken, DESTINATION, PATH};
 use crate::{
-    helpers::{call_basic_response_method, call_request_method, property},
+    helpers::{call_basic_response_method, call_request_method},
     Error, WindowIdentifier,
 };
 
@@ -589,10 +589,5 @@ impl<'a> PrintProxy<'a> {
             &(parent_window, title, fd.as_raw_fd(), &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -543,7 +543,7 @@ impl<'a> PrintProxy<'a> {
         settings: Settings,
         page_setup: PageSetup,
         options: PreparePrintOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method(
@@ -574,7 +574,7 @@ impl<'a> PrintProxy<'a> {
         title: &str,
         fd: F,
         options: PrintOptions,
-    ) -> Result<RequestProxy<'_>, Error>
+    ) -> Result<RequestProxy<'a>, Error>
     where
         F: AsRawFd + zvariant::Type + Serialize,
     {

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -511,6 +511,7 @@ pub struct PreparePrint {
 }
 
 /// The interface lets sandboxed applications print.
+#[derive(Debug)]
 pub struct PrintProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> PrintProxy<'a> {

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -164,6 +164,7 @@ pub struct SelectedDevices {
 }
 
 /// The interface lets sandboxed applications create remote desktop sessions.
+#[derive(Debug)]
 pub struct RemoteDesktopProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> RemoteDesktopProxy<'a> {

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -132,6 +132,11 @@ impl<'a> RemoteDesktopProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Create a remote desktop session.
     /// A remote desktop session is used to allow remote controlling a desktop
     /// session. It can also be used together with a screen cast session.

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -115,6 +115,7 @@ struct SelectedDevices {
 
 /// The interface lets sandboxed applications create remote desktop sessions.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.RemoteDesktop")]
 pub struct RemoteDesktopProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> RemoteDesktopProxy<'a> {

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -181,7 +181,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     pub async fn create_session(
         &self,
         options: CreateRemoteOptions,
-    ) -> Result<SessionProxy<'_>, Error> {
+    ) -> Result<SessionProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("CreateSession", &(options))
@@ -205,7 +205,7 @@ impl<'a> RemoteDesktopProxy<'a> {
         &self,
         session: &SessionProxy<'_>,
         options: SelectDevicesOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("SelectDevices", &(session, options))
@@ -233,7 +233,7 @@ impl<'a> RemoteDesktopProxy<'a> {
         session: &SessionProxy<'_>,
         parent_window: WindowIdentifier,
         options: StartRemoteOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("Start", &(session, parent_window, options))

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -192,19 +192,19 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
-    /// * `parent_window` - The application window identifier.
+    /// * `identifier` - The application window identifier.
     #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
     ) -> Result<BitFlags<DeviceType>, Error> {
         let options = StartRemoteOptions::default();
         let response: SelectedDevices = call_request_method(
             &self.0,
             &options.handle_token,
             "Start",
-            &(session, parent_window, &options),
+            &(session, identifier, &options),
         )
         .await?;
         Ok(response.devices)

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -48,8 +48,10 @@ use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use crate::{
     helpers::{call_basic_response_method, call_method, call_request_method, property},
-    Error, HandleToken, SessionProxy, WindowIdentifier,
+    Error, WindowIdentifier,
 };
+
+use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Type)]
 #[repr(u32)]
@@ -169,8 +171,8 @@ impl<'a> RemoteDesktopProxy<'a> {
     ) -> Result<RemoteDesktopProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.RemoteDesktop")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -2,8 +2,8 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::remote_desktop::{
-//!     CreateRemoteOptions, DeviceType, KeyState, RemoteDesktopProxy,
-//!     SelectDevicesOptions, StartRemoteOptions,
+//!     CreateRemoteOptions, DeviceType, KeyState, RemoteDesktopProxy, SelectDevicesOptions,
+//!     StartRemoteOptions,
 //! };
 //! use ashpd::{HandleToken, WindowIdentifier};
 //! use std::collections::HashMap;
@@ -13,24 +13,33 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = RemoteDesktopProxy::new(&connection).await?;
 //!
-//!     let session = proxy.create_session(
-//!         CreateRemoteOptions::default()
-//!             .session_handle_token(HandleToken::try_from("token").unwrap()),
-//!     ).await?;
+//!     let session = proxy
+//!         .create_session(
+//!             CreateRemoteOptions::default()
+//!                 .session_handle_token(HandleToken::try_from("token").unwrap()),
+//!         )
+//!         .await?;
 //!
-//!     proxy.select_devices(&session,
-//!         SelectDevicesOptions::default().types(DeviceType::Keyboard | DeviceType::Pointer),
-//!     ).await?;
+//!     proxy
+//!         .select_devices(
+//!             &session,
+//!             SelectDevicesOptions::default().types(DeviceType::Keyboard | DeviceType::Pointer),
+//!         )
+//!         .await?;
 //!
-//!     let devices = proxy.start(
-//!         &session,
-//!         WindowIdentifier::default(),
-//!         StartRemoteOptions::default(),
-//!     ).await?;
+//!     let devices = proxy
+//!         .start(
+//!             &session,
+//!             WindowIdentifier::default(),
+//!             StartRemoteOptions::default(),
+//!         )
+//!         .await?;
 //!     println!("{:#?}", devices);
 //!
 //!     // 13 for Enter key code
-//!     proxy.notify_keyboard_keycode(&session, HashMap::new(), 13, KeyState::Pressed).await?;
+//!     proxy
+//!         .notify_keyboard_keycode(&session, HashMap::new(), 13, KeyState::Pressed)
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -80,7 +89,7 @@ pub enum Axis {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a create a remote session request.
+/// Specified options for a [`RemoteDesktopProxy::create_session`] request.
 pub struct CreateRemoteOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -103,14 +112,14 @@ impl CreateRemoteOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
-/// A response to a `create_session` request.
+/// A response to a [`RemoteDesktopProxy::create_session`] request.
 struct CreateSession {
     /// A string that will be used as the last element of the session handle.
     pub(crate) session_handle: OwnedObjectPath,
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a select devices request.
+/// Specified options for a [`RemoteDesktopProxy::select_devices`] request.
 pub struct SelectDevicesOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -133,7 +142,7 @@ impl SelectDevicesOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a start remote desktop request.
+/// Specified options for a [`RemoteDesktopProxy::start`] request.
 pub struct StartRemoteOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -148,7 +157,7 @@ impl StartRemoteOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// A response to a select device request.
+/// A response to a [`RemoteDesktopProxy::select_devices`] request.
 pub struct SelectedDevices {
     /// The selected devices.
     pub devices: BitFlags<DeviceType>,
@@ -158,6 +167,7 @@ pub struct SelectedDevices {
 pub struct RemoteDesktopProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> RemoteDesktopProxy<'a> {
+    /// Create a new instance of [`RemoteDesktopProxy`].
     pub async fn new(
         connection: &zbus::azync::Connection,
     ) -> Result<RemoteDesktopProxy<'a>, Error> {
@@ -177,8 +187,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// # Arguments
     ///
     /// * `options` - A [`CreateRemoteOptions`].
-    ///
-    /// [`CreateRemoteOptions`]: ./struct.CreateRemoteOptions.html
     pub async fn create_session(
         &self,
         options: CreateRemoteOptions,
@@ -194,9 +202,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `options` - [`SelectDevicesOptions`].
-    ///
-    /// [`SelectDevicesOptions`]: ../struct.SelectDevicesOptions.html
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     pub async fn select_devices(
         &self,
         session: &SessionProxy<'_>,
@@ -216,9 +221,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - The application window identifier.
     /// * `options` - [`StartRemoteOptions`].
-    ///
-    /// [`StartRemoteOptions`]: ../struct.StartRemoteOptions.html
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
@@ -238,8 +240,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `options` - ?
     /// * `keycode` - Keyboard code that was pressed or released.
     /// * `state` - The new state of the keyboard code.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_keyboard_keycode(
@@ -268,8 +268,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `keysym` - Keyboard symbol that was pressed or released.
     /// * `state` - The new state of the keyboard code.
     ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
-    ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_keyboard_keysym(
         &self,
@@ -297,8 +295,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `options` - ?
     /// * `slot` - Touch slot where touch point appeared.
     ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
-    ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_touch_up(
         &self,
@@ -324,8 +320,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `slot` - Touch slot where touch point appeared.
     /// * `x` - Touch down x coordinate.
     /// * `y` - Touch down y coordinate.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_touch_down(
@@ -361,8 +355,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `x` - Touch motion x coordinate.
     /// * `y` - Touch motion y coordinate.
     ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
-    ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_touch_motion(
         &self,
@@ -393,8 +385,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `x` - Pointer motion x coordinate.
     /// * `y` - Pointer motion y coordinate.
     ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
-    ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_pointer_motion_absolute(
         &self,
@@ -422,8 +412,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `options` - ?
     /// * `dx` - Relative movement on the x axis.
     /// * `dy` - Relative movement on the y axis.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_pointer_motion(
@@ -454,8 +442,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `button` - The pointer button was pressed or released.
     /// * `state` - The new state of the keyboard code.
     ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
-    ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_pointer_button(
         &self,
@@ -481,8 +467,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `options` - ?
     /// * `axis` - The axis that was scrolled.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_pointer_axis_discrete(
@@ -514,8 +498,6 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `options` - ?
     /// * `dx` - Relative axis movement on the x axis.
     /// * `dy` - Relative axis movement on the y axis.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     ///
     /// FIXME: figure out the options we can take here
     pub async fn notify_pointer_axis(

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -28,7 +28,7 @@ use zvariant::{OwnedObjectPath, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use crate::{
-    helpers::{call_basic_response_method, call_method, call_request_method, property},
+    helpers::{call_basic_response_method, call_method, call_request_method},
     Error, WindowIdentifier,
 };
 
@@ -478,11 +478,9 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// Available source types.
     #[doc(alias = "AvailableDeviceTypes")]
     pub async fn available_device_types(&self) -> Result<BitFlags<DeviceType>, Error> {
-        property(&self.0, "AvailableDeviceTypes").await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
+        self.inner()
+            .get_property::<BitFlags<DeviceType>>("AvailableDeviceTypes")
+            .await
+            .map_err(From::from)
     }
 }

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -134,6 +134,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// Create a remote desktop session.
     /// A remote desktop session is used to allow remote controlling a desktop
     /// session. It can also be used together with a screen cast session.
+    #[doc(alias = "CreateSession")]
     pub async fn create_session(&self) -> Result<SessionProxy<'a>, Error> {
         let options = CreateRemoteOptions::default();
         let (proxy, session) = futures::try_join!(
@@ -160,6 +161,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `types` - The device types to request remote controlling of.
+    #[doc(alias = "SelectDevices")]
     pub async fn select_devices(
         &self,
         session: &SessionProxy<'_>,
@@ -185,6 +187,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - The application window identifier.
+    #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
@@ -210,6 +213,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `keycode` - Keyboard code that was pressed or released.
     /// * `state` - The new state of the keyboard code.
+    #[doc(alias = "NotifyKeyboardKeycode")]
     pub async fn notify_keyboard_keycode(
         &self,
         session: &SessionProxy<'_>,
@@ -235,6 +239,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `keysym` - Keyboard symbol that was pressed or released.
     /// * `state` - The new state of the keyboard code.
+    #[doc(alias = "NotifyKeyboardKeysym")]
     pub async fn notify_keyboard_keysym(
         &self,
         session: &SessionProxy<'_>,
@@ -260,6 +265,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `slot` - Touch slot where touch point appeared.
+    #[doc(alias = "NotifyTouchUp")]
     pub async fn notify_touch_up(
         &self,
         session: &SessionProxy<'_>,
@@ -284,6 +290,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `slot` - Touch slot where touch point appeared.
     /// * `x` - Touch down x coordinate.
     /// * `y` - Touch down y coordinate.
+    #[doc(alias = "NotifyTouchDown")]
     pub async fn notify_touch_down(
         &self,
         session: &SessionProxy<'_>,
@@ -316,6 +323,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `slot` - Touch slot where touch point appeared.
     /// * `x` - Touch motion x coordinate.
     /// * `y` - Touch motion y coordinate.
+    #[doc(alias = "NotifyTouchMotion")]
     pub async fn notify_touch_motion(
         &self,
         session: &SessionProxy<'_>,
@@ -344,6 +352,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `stream` - The PipeWire stream node the coordinate is relative to.
     /// * `x` - Pointer motion x coordinate.
     /// * `y` - Pointer motion y coordinate.
+    #[doc(alias = "NotifyPointerMotionAbsolute")]
     pub async fn notify_pointer_motion_absolute(
         &self,
         session: &SessionProxy<'_>,
@@ -370,6 +379,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `dx` - Relative movement on the x axis.
     /// * `dy` - Relative movement on the y axis.
+    #[doc(alias = "NotifyPointerMotion")]
     pub async fn notify_pointer_motion(
         &self,
         session: &SessionProxy<'_>,
@@ -378,12 +388,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     ) -> Result<(), Error> {
         // FIXME: figure out the options we can take here
         let options: HashMap<&str, Value<'_>> = HashMap::new();
-        call_method(
-            &self.0,
-            "NotifyPointerMotionAbsolute",
-            &(session, options, dx, dy),
-        )
-        .await
+        call_method(&self.0, "NotifyPointerMotion", &(session, options, dx, dy)).await
     }
 
     /// Notify pointer button.
@@ -397,6 +402,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `button` - The pointer button was pressed or released.
     /// * `state` - The new state of the keyboard code.
+    #[doc(alias = "NotifyPointerButton")]
     pub async fn notify_pointer_button(
         &self,
         session: &SessionProxy<'_>,
@@ -421,6 +427,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `axis` - The axis that was scrolled.
+    #[doc(alias = "NotifyPointerAxisDiscrete")]
     pub async fn notify_pointer_axis_discrete(
         &self,
         session: &SessionProxy<'_>,
@@ -450,6 +457,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `dx` - Relative axis movement on the x axis.
     /// * `dy` - Relative axis movement on the y axis.
+    #[doc(alias = "NotifyPointerAxis")]
     pub async fn notify_pointer_axis(
         &self,
         session: &SessionProxy<'_>,
@@ -462,6 +470,7 @@ impl<'a> RemoteDesktopProxy<'a> {
     }
 
     /// Available source types.
+    #[doc(alias = "AvailableDeviceTypes")]
     pub async fn available_device_types(&self) -> Result<BitFlags<DeviceType>, Error> {
         property(&self.0, "AvailableDeviceTypes").await
     }

--- a/src/desktop/request.rs
+++ b/src/desktop/request.rs
@@ -18,7 +18,7 @@ use crate::{desktop::HandleToken, helpers::call_method};
 /// A typical response returned by the [`RequestProxy::receive_response`] signal of a
 /// [`RequestProxy`].
 #[derive(Debug)]
-pub(crate) enum Response<T>
+enum Response<T>
 where
     T: DeserializeOwned + zvariant::Type,
 {

--- a/src/desktop/request.rs
+++ b/src/desktop/request.rs
@@ -13,7 +13,7 @@ use std::{
 use zvariant::OwnedValue;
 use zvariant_derive::Type;
 
-use crate::{helpers::call_method, HandleToken};
+use crate::{desktop::HandleToken, helpers::call_method};
 
 /// A typical response returned by the [`RequestProxy::receive_response`] signal of a
 /// [`RequestProxy`].
@@ -182,7 +182,7 @@ impl<'a> RequestProxy<'a> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Request")
             .path(path)?
-            .destination("org.freedesktop.portal.Desktop")
+            .destination(crate::desktop::DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy, connection.clone()))

--- a/src/desktop/request.rs
+++ b/src/desktop/request.rs
@@ -172,6 +172,7 @@ impl From<ResponseError> for ResponseType {
 /// This ensures that applications will work with both old and new versions of
 /// xdg-desktop-portal.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Request")]
 pub(crate) struct RequestProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> RequestProxy<'a> {

--- a/src/desktop/request.rs
+++ b/src/desktop/request.rs
@@ -206,6 +206,7 @@ impl<'a> RequestProxy<'a> {
         &self.0
     }
 
+    #[doc(alias = "Response")]
     pub async fn receive_response<R>(&self) -> Result<R, crate::Error>
     where
         R: DeserializeOwned + zvariant::Type + Debug,
@@ -222,6 +223,7 @@ impl<'a> RequestProxy<'a> {
     /// related user interaction (dialogs, etc). A Response signal will not
     /// be emitted in this case.
     #[allow(dead_code)]
+    #[doc(alias = "Close")]
     pub async fn close(&self) -> Result<(), crate::Error> {
         call_method(&self.0, "Close", &()).await
     }

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -49,9 +49,10 @@ use std::collections::HashMap;
 use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
     helpers::{call_basic_response_method, call_method, call_request_method, property},
-    Error, HandleToken, SessionProxy, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Copy, Clone, Debug, Type, BitFlags)]
@@ -216,8 +217,8 @@ impl<'a> ScreenCastProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<ScreenCastProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.ScreenCast")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -227,7 +227,7 @@ impl<'a> ScreenCastProxy<'a> {
     pub async fn create_session(
         &self,
         options: CreateSessionOptions,
-    ) -> Result<SessionProxy<'_>, Error> {
+    ) -> Result<SessionProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("CreateSession", &(options))
@@ -283,7 +283,7 @@ impl<'a> ScreenCastProxy<'a> {
         &self,
         session: &SessionProxy<'_>,
         options: SelectSourcesOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("SelectSources", &(session, options))
@@ -311,7 +311,7 @@ impl<'a> ScreenCastProxy<'a> {
         session: &SessionProxy<'_>,
         parent_window: WindowIdentifier,
         options: StartCastOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("Start", &(session, parent_window, options))

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -216,6 +216,7 @@ pub struct StreamProperties {
 }
 
 /// The interface lets sandboxed applications create screen cast sessions.
+#[derive(Debug)]
 pub struct ScreenCastProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenCastProxy<'a> {

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -43,7 +43,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use super::{HandleToken, SessionProxy, DESTINATION, PATH};
 use crate::{
-    helpers::{call_basic_response_method, call_method, call_request_method, property},
+    helpers::{call_basic_response_method, call_method, call_request_method},
     Error, WindowIdentifier,
 };
 
@@ -293,17 +293,18 @@ impl<'a> ScreenCastProxy<'a> {
     /// Available cursor mode.
     #[doc(alias = "AvailableCursorModes")]
     pub async fn available_cursor_modes(&self) -> Result<BitFlags<CursorMode>, Error> {
-        property(&self.0, "AvailableCursorModes").await
+        self.inner()
+            .get_property::<BitFlags<CursorMode>>("AvailableCursorModes")
+            .await
+            .map_err(From::from)
     }
 
     /// Available source types.
     #[doc(alias = "AvailableSourceTypes")]
     pub async fn available_source_types(&self) -> Result<BitFlags<SourceType>, Error> {
-        property(&self.0, "AvailableSourceTypes").await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
+        self.inner()
+            .get_property::<BitFlags<SourceType>>("AvailableSourceTypes")
+            .await
+            .map_err(From::from)
     }
 }

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -5,8 +5,8 @@
 //!
 //! ```rust,no_run
 //! use ashpd::desktop::screencast::{
-//!     CreateSessionOptions, CursorMode, ScreenCastProxy, SelectSourcesOptions,
-//!     SourceType, StartCastOptions, Streams,
+//!     CreateSessionOptions, CursorMode, ScreenCastProxy, SelectSourcesOptions, SourceType,
+//!     StartCastOptions,
 //! };
 //! use ashpd::{HandleToken, SessionProxy, WindowIdentifier};
 //! use enumflags2::BitFlags;
@@ -20,21 +20,26 @@
 //!     let session_token = HandleToken::try_from("session120").unwrap();
 //!
 //!     let session = proxy
-//!         .create_session(CreateSessionOptions::default().session_handle_token(session_token)).await?;
+//!         .create_session(CreateSessionOptions::default().session_handle_token(session_token))
+//!         .await?;
 //!
-//!     proxy.select_sources(
-//!         &session,
-//!         SelectSourcesOptions::default()
-//!             .multiple(true)
-//!             .cursor_mode(BitFlags::from(CursorMode::Metadata))
-//!             .types(SourceType::Monitor | SourceType::Window),
-//!     ).await?;
+//!     proxy
+//!         .select_sources(
+//!             &session,
+//!             SelectSourcesOptions::default()
+//!                 .multiple(true)
+//!                 .cursor_mode(BitFlags::from(CursorMode::Metadata))
+//!                 .types(SourceType::Monitor | SourceType::Window),
+//!         )
+//!         .await?;
 //!
-//!     let response = proxy.start(
-//!         &session,
-//!         WindowIdentifier::default(),
-//!         StartCastOptions::default(),
-//!     ).await?;
+//!     let response = proxy
+//!         .start(
+//!             &session,
+//!             WindowIdentifier::default(),
+//!             StartCastOptions::default(),
+//!         )
+//!         .await?;
 //!
 //!     response.streams().iter().for_each(|stream| {
 //!         println!("{}", stream.pipe_wire_node_id());
@@ -81,7 +86,7 @@ pub enum CursorMode {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a create a Screen Cast session request.
+/// Specified options for a [`ScreenCastProxy::create_session`] request.
 pub struct CreateSessionOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -104,7 +109,7 @@ impl CreateSessionOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a select sources request.
+/// Specified options for a [`ScreenCastProxy::select_sources`] request.
 pub struct SelectSourcesOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -143,7 +148,7 @@ impl SelectSourcesOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a start Screen Cast request.
+/// Specified options for a [`ScreenCastProxy::start`] request.
 pub struct StartCastOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -158,7 +163,7 @@ impl StartCastOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
-/// A response to the create session request.
+/// A response to a [`ScreenCastProxy::create_session`] request.
 struct CreateSession {
     /// A string that will be used as the last element of the session handle.
     // TODO: investigate why this doesn't return an ObjectPath
@@ -166,7 +171,7 @@ struct CreateSession {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
-/// A response to start the Stream Cast request.
+/// A response to a [`ScreenCastProxy::start`] request.
 pub struct Streams {
     streams: Vec<Stream>,
 }
@@ -214,6 +219,7 @@ pub struct StreamProperties {
 pub struct ScreenCastProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenCastProxy<'a> {
+    /// Create a new instance of [`ScreenCastProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<ScreenCastProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.ScreenCast")
@@ -248,8 +254,6 @@ impl<'a> ScreenCastProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `options` - ?
     /// FIXME: figure out the options we can take here
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     pub async fn open_pipe_wire_remote(
         &self,
         session: &SessionProxy<'_>,
@@ -268,9 +272,7 @@ impl<'a> ScreenCastProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
-    /// * `options` - A `SelectSourcesOptions`.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
+    /// * `options` - A [`SelectSourcesOptions`].
     pub async fn select_sources(
         &self,
         session: &SessionProxy<'_>,
@@ -291,8 +293,6 @@ impl<'a> ScreenCastProxy<'a> {
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - A `StartScreenCastOptions`.
-    ///
-    /// [`SessionProxy`]: ../../session/struct.SessionProxy.html
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -189,6 +189,11 @@ impl<'a> ScreenCastProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Create a screen cast session.
     #[doc(alias = "CreateSession")]
     pub async fn create_session(&self) -> Result<SessionProxy<'a>, Error> {

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -189,6 +189,7 @@ impl<'a> ScreenCastProxy<'a> {
     }
 
     /// Create a screen cast session.
+    #[doc(alias = "CreateSession")]
     pub async fn create_session(&self) -> Result<SessionProxy<'a>, Error> {
         let options = CreateSessionOptions::default();
         let (proxy, session) = futures::try_join!(
@@ -214,6 +215,7 @@ impl<'a> ScreenCastProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
+    #[doc(alias = "OpenPipeWireRemote")]
     pub async fn open_pipe_wire_remote(&self, session: &SessionProxy<'_>) -> Result<Fd, Error> {
         // FIXME: figure out the options we can take here
         let options: HashMap<&str, Value<'_>> = HashMap::new();
@@ -233,6 +235,7 @@ impl<'a> ScreenCastProxy<'a> {
     /// * `cursor_mode` - Sets how the cursor will be drawn on the screen cast stream.
     /// * `types` - Sets the types of content to record.
     /// * `multiple`- Sets whether to allow selecting multiple sources.
+    #[doc(alias = "SelectSources")]
     pub async fn select_sources(
         &self,
         session: &SessionProxy<'_>,
@@ -264,7 +267,7 @@ impl<'a> ScreenCastProxy<'a> {
     ///
     /// * `session` - A [`SessionProxy`].
     /// * `parent_window` - Identifier for the application window.
-    /// * `options` - A `StartScreenCastOptions`.
+    #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
@@ -282,11 +285,13 @@ impl<'a> ScreenCastProxy<'a> {
     }
 
     /// Available cursor mode.
+    #[doc(alias = "AvailableCursorModes")]
     pub async fn available_cursor_modes(&self) -> Result<BitFlags<CursorMode>, Error> {
         property(&self.0, "AvailableCursorModes").await
     }
 
     /// Available source types.
+    #[doc(alias = "AvailableSourceTypes")]
     pub async fn available_source_types(&self) -> Result<BitFlags<SourceType>, Error> {
         property(&self.0, "AvailableSourceTypes").await
     }

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -174,6 +174,7 @@ struct StreamProperties {
 
 /// The interface lets sandboxed applications create screen cast sessions.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.ScreenCast")]
 pub struct ScreenCastProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenCastProxy<'a> {

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -272,19 +272,19 @@ impl<'a> ScreenCastProxy<'a> {
     /// # Arguments
     ///
     /// * `session` - A [`SessionProxy`].
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     #[doc(alias = "Start")]
     pub async fn start(
         &self,
         session: &SessionProxy<'_>,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
     ) -> Result<Vec<Stream>, Error> {
         let options = StartCastOptions::default();
         let streams: Streams = call_request_method(
             &self.0,
             &options.handle_token,
             "Start",
-            &(session, parent_window, &options),
+            &(session, identifier, &options),
         )
         .await?;
         Ok(streams.streams.to_vec())

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -35,10 +35,7 @@
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use super::{HandleToken, DESTINATION, PATH};
-use crate::{
-    helpers::{call_request_method, property},
-    Error, WindowIdentifier,
-};
+use crate::{helpers::call_request_method, Error, WindowIdentifier};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
 /// Specified options for a [`ScreenshotProxy::screenshot`] request.
@@ -209,10 +206,5 @@ impl<'a> ScreenshotProxy<'a> {
             &(parent_window, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -169,15 +169,15 @@ impl<'a> ScreenshotProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     #[doc(alias = "PickColor")]
-    pub async fn pick_color(&self, parent_window: WindowIdentifier) -> Result<Color, Error> {
+    pub async fn pick_color(&self, identifier: WindowIdentifier) -> Result<Color, Error> {
         let options = PickColorOptions::default();
         call_request_method(
             &self.0,
             &options.handle_token,
             "PickColor",
-            &(parent_window, &options),
+            &(identifier, &options),
         )
         .await
     }
@@ -186,13 +186,13 @@ impl<'a> ScreenshotProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `interactive` - Sets whether the dialog should offer customization before a screenshot or not.
     /// * `modal` - Sets whether the dialog should be a modal.
     #[doc(alias = "Screenshot")]
     pub async fn screenshot(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         interactive: bool,
         modal: bool,
     ) -> Result<Screenshot, Error> {
@@ -203,7 +203,7 @@ impl<'a> ScreenshotProxy<'a> {
             &self.0,
             &options.handle_token,
             "Screenshot",
-            &(parent_window, &options),
+            &(identifier, &options),
         )
         .await
     }

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -148,6 +148,7 @@ impl std::fmt::Debug for Color {
 
 /// The interface lets sandboxed applications request a screenshot.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Screenshot")]
 pub struct ScreenshotProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenshotProxy<'a> {

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -165,6 +165,7 @@ impl std::fmt::Debug for Color {
 }
 
 /// The interface lets sandboxed applications request a screenshot.
+#[derive(Debug)]
 pub struct ScreenshotProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenshotProxy<'a> {

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -46,9 +46,10 @@
 
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
+use super::{HandleToken, DESTINATION, PATH};
 use crate::{
     helpers::{call_request_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
@@ -173,8 +174,8 @@ impl<'a> ScreenshotProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<ScreenshotProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Screenshot")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -167,6 +167,7 @@ impl<'a> ScreenshotProxy<'a> {
     /// # Arguments
     ///
     /// * `parent_window` - Identifier for the application window.
+    #[doc(alias = "PickColor")]
     pub async fn pick_color(&self, parent_window: WindowIdentifier) -> Result<Color, Error> {
         let options = PickColorOptions::default();
         call_request_method(
@@ -185,6 +186,7 @@ impl<'a> ScreenshotProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `interactive` - Sets whether the dialog should offer customization before a screenshot or not.
     /// * `modal` - Sets whether the dialog should be a modal.
+    #[doc(alias = "Screenshot")]
     pub async fn screenshot(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -163,6 +163,11 @@ impl<'a> ScreenshotProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Obtains the color of a single pixel.
     ///
     /// # Arguments

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -1,32 +1,43 @@
 //! # Examples
 //!
-//! Taking a screenshot
+//! ## Taking a screenshot
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::{ScreenshotProxy, ScreenshotOptions}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::screenshot::{ScreenshotOptions, ScreenshotProxy},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = ScreenshotProxy::new(&connection).await?;
-//!     let screenshot = proxy.screenshot(identifier, ScreenshotOptions::default().interactive(true)).await?;
+//!     let screenshot = proxy
+//!         .screenshot(identifier, ScreenshotOptions::default().interactive(true))
+//!         .await?;
 //!     println!("URI: {}", screenshot.uri);
 //!
 //!     Ok(())
 //! }
 //! ```
 //!
-//! Picking a color
+//! ## Picking a color
+//!
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::{ScreenshotProxy, PickColorOptions}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::screenshot::{PickColorOptions, ScreenshotProxy},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = ScreenshotProxy::new(&connection).await?;
-//!     let color = proxy.pick_color(identifier, PickColorOptions::default()).await?;
+//!     let color = proxy
+//!         .pick_color(identifier, PickColorOptions::default())
+//!         .await?;
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
 //!
 //!     Ok(())
@@ -41,7 +52,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// Specified options on a screenshot request.
+/// Specified options for a [`ScreenshotProxy::screenshot`] request.
 pub struct ScreenshotOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -74,14 +85,14 @@ impl ScreenshotOptions {
 }
 
 #[derive(DeserializeDict, SerializeDict, Clone, TypeDict, Debug)]
-/// A response to a screenshot request.
+/// A response to a [`ScreenshotProxy::screenshot`] request.
 pub struct Screenshot {
     /// The screenshot uri.
     pub uri: String,
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Clone, Debug, Default)]
-/// Specified options on a pick color request.
+/// Specified options for a [`ScreenshotProxy::pick_color`] request.
 pub struct PickColorOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: Option<HandleToken>,
@@ -96,7 +107,7 @@ impl PickColorOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Clone, Copy, PartialEq, TypeDict)]
-/// A response to a pick color request.
+/// A response to a [`ScreenshotProxy::pick_color`] request.
 /// **Note** the values are normalized.
 pub struct Color {
     color: ([f64; 3]),
@@ -157,6 +168,7 @@ impl std::fmt::Debug for Color {
 pub struct ScreenshotProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> ScreenshotProxy<'a> {
+    /// Create a new instance of [`ScreenshotProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<ScreenshotProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Screenshot")
@@ -173,8 +185,6 @@ impl<'a> ScreenshotProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - A [`PickColorOptions`].
-    ///
-    /// [`PickColorOptions`]: ./struct.PickColorOptions.html
     pub async fn pick_color(
         &self,
         parent_window: WindowIdentifier,
@@ -189,8 +199,6 @@ impl<'a> ScreenshotProxy<'a> {
     ///
     /// * `parent_window` - Identifier for the application window.
     /// * `options` - A [`ScreenshotOptions`].
-    ///
-    /// [`ScreenshotOptions`]: ./struct.ScreenshotOptions.html
     pub async fn screenshot(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -171,7 +171,7 @@ impl<'a> ScreenshotProxy<'a> {
         &self,
         parent_window: WindowIdentifier,
         options: PickColorOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("PickColor", &(parent_window, options))
@@ -192,7 +192,7 @@ impl<'a> ScreenshotProxy<'a> {
         &self,
         parent_window: WindowIdentifier,
         options: ScreenshotOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("Screenshot", &(parent_window, options))

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -55,7 +55,7 @@ use crate::{
 /// Specified options for a [`ScreenshotProxy::screenshot`] request.
 pub struct ScreenshotOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
     /// Whether the dialog should be modal.
     modal: Option<bool>,
     /// Hint whether the dialog should offer customization before taking a
@@ -66,7 +66,7 @@ pub struct ScreenshotOptions {
 impl ScreenshotOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 
@@ -95,13 +95,13 @@ pub struct Screenshot {
 /// Specified options for a [`ScreenshotProxy::pick_color`] request.
 pub struct PickColorOptions {
     /// A string that will be used as the last element of the handle.
-    handle_token: Option<HandleToken>,
+    handle_token: HandleToken,
 }
 
 impl PickColorOptions {
     /// Sets the handle token.
     pub fn handle_token(mut self, handle_token: HandleToken) -> Self {
-        self.handle_token = Some(handle_token);
+        self.handle_token = handle_token;
         self
     }
 }
@@ -191,7 +191,13 @@ impl<'a> ScreenshotProxy<'a> {
         parent_window: WindowIdentifier,
         options: PickColorOptions,
     ) -> Result<Color, Error> {
-        call_request_method(&self.0, "PickColor", &(parent_window, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "PickColor",
+            &(parent_window, &options),
+        )
+        .await
     }
 
     /// Takes a screenshot.
@@ -205,7 +211,13 @@ impl<'a> ScreenshotProxy<'a> {
         parent_window: WindowIdentifier,
         options: ScreenshotOptions,
     ) -> Result<Screenshot, Error> {
-        call_request_method(&self.0, "Screenshot", &(parent_window, options)).await
+        call_request_method(
+            &self.0,
+            &options.handle_token,
+            "Screenshot",
+            &(parent_window, &options),
+        )
+        .await
     }
 
     /// The version of this DBus interface.

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -67,7 +67,7 @@ impl<'a> SecretProxy<'a> {
         &self,
         fd: F,
         options: RetrieveOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("RetrieveSecret", &(fd.as_raw_fd(), options))

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -64,6 +64,11 @@ impl<'a> SecretProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Retrieves a master secret for a sandboxed application.
     ///
     /// # Arguments

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -28,6 +28,8 @@ use crate::{
 use std::os::unix::prelude::AsRawFd;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
+use super::{DESTINATION, PATH};
+
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
 /// Specified options for a [`SecretProxy::retrieve_secret`] request.
 pub struct RetrieveOptions {
@@ -54,8 +56,8 @@ impl<'a> SecretProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<SecretProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Secret")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -12,7 +12,9 @@
 //!
 //!     let file = File::open("test.txt").unwrap();
 //!
-//!     let secret = proxy.retrieve_secret(Fd::from(file.as_raw_fd()), RetrieveOptions::default()).await?;
+//!     let secret = proxy
+//!         .retrieve_secret(Fd::from(file.as_raw_fd()), RetrieveOptions::default())
+//!         .await?;
 //!
 //!     println!("{:#?}", secret);
 //!     Ok(())
@@ -27,14 +29,14 @@ use std::os::unix::prelude::AsRawFd;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a retrieve secret request.
+/// Specified options for a [`SecretProxy::retrieve_secret`] request.
 pub struct RetrieveOptions {
     /// A string returned by a previous call to `retrieve_secret`.
     token: Option<String>,
 }
 
 impl RetrieveOptions {
-    /// Sets the token received on a previous call to `retrieve_secret`.
+    /// Sets the token received on a previous call to [`SecretProxy::retrieve_secret`].
     pub fn token(mut self, token: &str) -> Self {
         self.token = Some(token.to_string());
         self
@@ -47,6 +49,7 @@ impl RetrieveOptions {
 pub struct SecretProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SecretProxy<'a> {
+    /// Create a new instance of [`SecretProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<SecretProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Secret")
@@ -62,9 +65,7 @@ impl<'a> SecretProxy<'a> {
     /// # Arguments
     ///
     /// * `fd` - Writable file descriptor for transporting the secret.
-    /// * `options` - A `RetrieveOptions`.
-    ///
-    /// [`RetrieveOptions`]: ./struct.RetrieveOptions.html
+    /// * `options` - A [`RetrieveOptions`].
     pub async fn retrieve_secret<F: AsRawFd + serde::Serialize + zvariant::Type>(
         &self,
         fd: F,

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -69,6 +69,7 @@ impl<'a> SecretProxy<'a> {
     ///
     /// * `fd` - Writable file descriptor for transporting the secret.
     /// * `token` -  A string returned by a previous call to [`SecretProxy::retrieve_secret`].
+    #[doc(alias = "RetrieveSecret")]
     pub async fn retrieve_secret<F: AsRawFd + serde::Serialize + zvariant::Type>(
         &self,
         fd: F,

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -21,10 +21,7 @@
 //! }
 //! ```
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use std::os::unix::prelude::AsRawFd;
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
@@ -87,10 +84,5 @@ impl<'a> SecretProxy<'a> {
             RetrieveOptions::default()
         };
         call_method(&self.0, "RetrieveSecret", &(fd.as_raw_fd(), options)).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -49,6 +49,7 @@ impl RetrieveOptions {
 /// The secret can then be used for encrypting confidential data inside the
 /// sandbox.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Secret")]
 pub struct SecretProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SecretProxy<'a> {

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -46,6 +46,7 @@ impl RetrieveOptions {
 /// The interface lets sandboxed applications retrieve a per-application secret.
 /// The secret can then be used for encrypting confidential data inside the
 /// sandbox.
+#[derive(Debug)]
 pub struct SecretProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SecretProxy<'a> {

--- a/src/desktop/session.rs
+++ b/src/desktop/session.rs
@@ -20,6 +20,7 @@ pub type SessionDetails = HashMap<String, OwnedValue>;
 /// [`SessionProxy::receive_closed`]. Whether it is allowed to directly
 /// call [`SessionProxy::close`] depends on the interface.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Session")]
 pub struct SessionProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> SessionProxy<'a> {

--- a/src/desktop/session.rs
+++ b/src/desktop/session.rs
@@ -58,6 +58,7 @@ impl<'a> SessionProxy<'a> {
     }
 
     /// Emitted when a session is closed.
+    #[doc(alias = "Closed")]
     pub async fn receive_closed(&self) -> Result<SessionDetails, Error> {
         let mut stream = self.0.receive_signal("Closed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -66,6 +67,7 @@ impl<'a> SessionProxy<'a> {
 
     /// Closes the portal session to which this object refers and ends all
     /// related user interaction (dialogs, etc).
+    #[doc(alias = "Close")]
     pub async fn close(&self) -> Result<(), Error> {
         call_method(&self.0, "Close", &()).await
     }

--- a/src/desktop/session.rs
+++ b/src/desktop/session.rs
@@ -1,6 +1,6 @@
 use crate::{
     desktop::{HandleToken, DESTINATION},
-    helpers::{call_method, property},
+    helpers::call_method,
     Error,
 };
 use futures::prelude::stream::*;
@@ -71,11 +71,6 @@ impl<'a> SessionProxy<'a> {
     #[doc(alias = "Close")]
     pub async fn close(&self) -> Result<(), Error> {
         call_method(&self.0, "Close", &()).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }
 

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -7,7 +7,9 @@
 //!
 //!     println!(
 //!         "{:#?}",
-//!         proxy.read::<String>("org.gnome.desktop.interface", "clock-format").await?
+//!         proxy
+//!             .read::<String>("org.gnome.desktop.interface", "clock-format")
+//!             .await?
 //!     );
 //!
 //!     let settings = proxy.read_all(&["org.gnome.desktop.interface"]).await?;
@@ -74,6 +76,7 @@ impl std::fmt::Debug for Setting {
 pub struct SettingsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SettingsProxy<'a> {
+    /// Create a new instance of [`SettingsProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<SettingsProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Settings")

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -76,6 +76,7 @@ impl std::fmt::Debug for Setting {
 /// required for toolkits similar to XSettings. It is not for general purpose
 /// settings.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Settings")]
 pub struct SettingsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SettingsProxy<'a> {

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -101,6 +101,7 @@ impl<'a> SettingsProxy<'a> {
     /// If `namespaces` is an empty array or contains an empty string it matches
     /// all. Globing is supported but only for trailing sections, e.g.
     /// "org.example.*".
+    #[doc(alias = "ReadAll")]
     pub async fn read_all(&self, namespaces: &[&str]) -> Result<HashMap<String, Namespace>, Error> {
         call_method(&self.0, "ReadAll", &(namespaces)).await
     }
@@ -113,6 +114,7 @@ impl<'a> SettingsProxy<'a> {
     ///
     /// * `namespace` - Namespace to look up key in.
     /// * `key` - The key to get.
+    #[doc(alias = "Read")]
     pub async fn read<T>(&self, namespace: &str, key: &str) -> Result<T, Error>
     where
         T: TryFrom<OwnedValue> + DeserializeOwned + zvariant::Type,
@@ -121,6 +123,7 @@ impl<'a> SettingsProxy<'a> {
     }
 
     /// Signal emitted when a setting changes.
+    #[doc(alias = "SettingChanged")]
     pub async fn receive_setting_changed(&self) -> Result<Setting, Error> {
         let mut stream = self.0.receive_signal("SettingChanged").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -26,7 +26,7 @@
 
 use std::{collections::HashMap, convert::TryFrom};
 
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use zvariant::OwnedValue;
 use zvariant_derive::Type;

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -36,6 +36,8 @@ use crate::{
     Error,
 };
 
+use super::{DESTINATION, PATH};
+
 /// A HashMap of the <key, value> settings found on a specific namespace.
 pub type Namespace = HashMap<String, OwnedValue>;
 
@@ -81,8 +83,8 @@ impl<'a> SettingsProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<SettingsProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Settings")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -91,6 +91,11 @@ impl<'a> SettingsProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Reads a single value. Returns an error on any unknown namespace or key.
     ///
     /// Returns a `HashMap` of namespaces to its keys and values.

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -73,6 +73,7 @@ impl std::fmt::Debug for Setting {
 /// The interface provides read-only access to a small number of host settings
 /// required for toolkits similar to XSettings. It is not for general purpose
 /// settings.
+#[derive(Debug)]
 pub struct SettingsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> SettingsProxy<'a> {

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -31,10 +31,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use zvariant::OwnedValue;
 use zvariant_derive::Type;
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 
 use super::{DESTINATION, PATH};
 
@@ -134,10 +131,5 @@ impl<'a> SettingsProxy<'a> {
         let mut stream = self.0.receive_signal("SettingChanged").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
         message.body::<Setting>().map_err(From::from)
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -30,6 +30,8 @@ use std::os::unix::io::AsRawFd;
 use zvariant::Type;
 use zvariant_derive::Type;
 
+use super::{DESTINATION, PATH};
+
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Clone, Copy, Hash, Debug, Type)]
 #[repr(u32)]
 /// The status of moving a file to the trash.
@@ -49,8 +51,8 @@ impl<'a> TrashProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<TrashProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Trash")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -55,6 +55,11 @@ impl<'a> TrashProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Sends a file to the trashcan.
     /// Applications are allowed to trash a file if they can open it in
     /// read/write mode.

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -41,6 +41,7 @@ pub enum TrashStatus {
 }
 
 /// The interface lets sandboxed applications send files to the trashcan.
+#[derive(Debug)]
 pub struct TrashProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> TrashProxy<'a> {

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -61,6 +61,7 @@ impl<'a> TrashProxy<'a> {
     /// # Arguments
     ///
     /// * `fd` - The file descriptor.
+    #[doc(alias = "TrashFile")]
     pub async fn trash_file<T>(&self, fd: T) -> Result<(), Error>
     where
         T: AsRawFd + Type + Serialize,

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -20,7 +20,10 @@
 //! }
 //! ```
 
-use crate::Error;
+use crate::{
+    helpers::{call_method, property},
+    Error,
+};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::os::unix::io::AsRawFd;
@@ -62,18 +65,11 @@ impl<'a> TrashProxy<'a> {
     where
         T: AsRawFd + Type + Serialize,
     {
-        self.0
-            .call_method("TrashFile", &(fd.as_raw_fd()))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "TrashFile", &(fd.as_raw_fd())).await
     }
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -16,10 +16,7 @@
 //! }
 //! ```
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::os::unix::io::AsRawFd;
@@ -77,10 +74,5 @@ impl<'a> TrashProxy<'a> {
             TrashStatus::Failed => Err(Error::TrashFailed),
             TrashStatus::Succeeded => Ok(()),
         }
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -40,6 +40,7 @@ enum TrashStatus {
 
 /// The interface lets sandboxed applications send files to the trashcan.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Trash")]
 pub struct TrashProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> TrashProxy<'a> {

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -1,10 +1,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
+//! use ashpd::desktop::trash::{TrashProxy, TrashStatus};
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
 //! use zvariant::Fd;
-//! use ashpd::desktop::trash::{TrashProxy, TrashStatus};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
@@ -44,6 +44,7 @@ pub enum TrashStatus {
 pub struct TrashProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> TrashProxy<'a> {
+    /// Create a new instance of [`TrashProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<TrashProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Trash")

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -134,6 +134,7 @@ impl<'a> WallpaperProxy<'a> {
     /// * `fd` - The wallpaper file description.
     /// * `show_preview` - Whether to show a preview of the picture.
     /// * `set_on` - Where to set the wallpaper on.
+    #[doc(alias = "SetWallpaperFile")]
     pub async fn set_wallpaper_file<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -164,6 +165,7 @@ impl<'a> WallpaperProxy<'a> {
     /// * `uri` - The wallpaper URI.
     /// * `show_preview` - Whether to show a preview of the picture.
     /// * `set_on` - Where to set the wallpaper on.
+    #[doc(alias = "SetWallpaperURI")]
     pub async fn set_wallpaper_uri(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -123,6 +123,7 @@ impl WallpaperOptions {
 
 /// The interface lets sandboxed applications set the user's desktop background
 /// picture.
+#[derive(Debug)]
 pub struct WallpaperProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> WallpaperProxy<'a> {

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -61,8 +61,9 @@ use zvariant::{Signature, Type};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
+    desktop::{HandleToken, DESTINATION, PATH},
     helpers::{call_basic_response_method, property},
-    Error, HandleToken, WindowIdentifier,
+    Error, WindowIdentifier,
 };
 
 #[derive(
@@ -139,8 +140,8 @@ impl<'a> WallpaperProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<WallpaperProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Wallpaper")
-            .path("/org/freedesktop/portal/desktop")?
-            .destination("org.freedesktop.portal.Desktop")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -136,14 +136,14 @@ impl<'a> WallpaperProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `fd` - The wallpaper file description.
     /// * `show_preview` - Whether to show a preview of the picture.
     /// * `set_on` - Where to set the wallpaper on.
     #[doc(alias = "SetWallpaperFile")]
     pub async fn set_wallpaper_file<F>(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         fd: F,
         show_preview: bool,
         set_on: SetOn,
@@ -158,7 +158,7 @@ impl<'a> WallpaperProxy<'a> {
             &self.0,
             &options.handle_token,
             "SetWallpaperFile",
-            &(parent_window, fd.as_raw_fd(), &options),
+            &(identifier, fd.as_raw_fd(), &options),
         )
         .await
     }
@@ -167,14 +167,14 @@ impl<'a> WallpaperProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `parent_window` - Identifier for the application window.
+    /// * `identifier` - Identifier for the application window.
     /// * `uri` - The wallpaper URI.
     /// * `show_preview` - Whether to show a preview of the picture.
     /// * `set_on` - Where to set the wallpaper on.
     #[doc(alias = "SetWallpaperURI")]
     pub async fn set_wallpaper_uri(
         &self,
-        parent_window: WindowIdentifier,
+        identifier: WindowIdentifier,
         uri: &str,
         show_preview: bool,
         set_on: SetOn,
@@ -186,7 +186,7 @@ impl<'a> WallpaperProxy<'a> {
             &self.0,
             &options.handle_token,
             "SetWallpaperURI",
-            &(parent_window, uri, &options),
+            &(identifier, uri, &options),
         )
         .await
     }

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -126,6 +126,11 @@ impl<'a> WallpaperProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Sets the lock-screen, background or both wallpaper's from a file
     /// descriptor.
     ///

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -111,6 +111,7 @@ impl WallpaperOptions {
 /// The interface lets sandboxed applications set the user's desktop background
 /// picture.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Wallpaper")]
 pub struct WallpaperProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> WallpaperProxy<'a> {

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -1,11 +1,14 @@
 //! # Examples
 //!
-//! Sets a wallpaper from a file:
+//! ## Sets a wallpaper from a file:
 //!
 //! ```rust,no_run
+//! use ashpd::{
+//!     desktop::wallpaper::{SetOn, WallpaperOptions, WallpaperProxy},
+//!     WindowIdentifier,
+//! };
 //! use std::fs::File;
 //! use std::os::unix::io::AsRawFd;
-//! use ashpd::{desktop::wallpaper::{SetOn, WallpaperProxy, WallpaperOptions}, WindowIdentifier};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
@@ -27,10 +30,13 @@
 //! }
 //! ```
 //!
-//! Sets a wallpaper from a URI:
+//! ## Sets a wallpaper from a URI:
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::wallpaper::{SetOn, WallpaperProxy, WallpaperOptions}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::wallpaper::{SetOn, WallpaperOptions, WallpaperProxy},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
@@ -89,7 +95,7 @@ impl Serialize for SetOn {
 }
 
 #[derive(SerializeDict, DeserializeDict, Clone, TypeDict, Debug, Default)]
-/// Specified options for a set wallpaper request.
+/// Specified options for a [`WallpaperProxy::set_wallpaper_file`] or a [`WallpaperProxy::set_wallpaper_uri`] request.
 pub struct WallpaperOptions {
     /// Whether to show a preview of the picture
     #[zvariant(rename = "show-preview")]
@@ -120,6 +126,7 @@ impl WallpaperOptions {
 pub struct WallpaperProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> WallpaperProxy<'a> {
+    /// Create a new instance of [`WallpaperProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<WallpaperProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Wallpaper")
@@ -138,8 +145,6 @@ impl<'a> WallpaperProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `fd` - The wallpaper file description.
     /// * `options` - A [`WallpaperOptions`].
-    ///
-    /// [`WallpaperOptions`]: ./struct.WallpaperOptions.html
     pub async fn set_wallpaper_file<F>(
         &self,
         parent_window: WindowIdentifier,
@@ -164,8 +169,6 @@ impl<'a> WallpaperProxy<'a> {
     /// * `parent_window` - Identifier for the application window.
     /// * `uri` - The wallpaper URI.
     /// * `options` - A [`WallpaperOptions`].
-    ///
-    /// [`WallpaperOptions`]: ./struct.WallpaperOptions.html
     pub async fn set_wallpaper_uri(
         &self,
         parent_window: WindowIdentifier,

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -138,7 +138,7 @@ impl<'a> WallpaperProxy<'a> {
         parent_window: WindowIdentifier,
         fd: F,
         options: WallpaperOptions,
-    ) -> Result<RequestProxy<'_>, Error>
+    ) -> Result<RequestProxy<'a>, Error>
     where
         F: AsRawFd + Type + Serialize,
     {
@@ -164,7 +164,7 @@ impl<'a> WallpaperProxy<'a> {
         parent_window: WindowIdentifier,
         uri: &str,
         options: WallpaperOptions,
-    ) -> Result<RequestProxy<'_>, Error> {
+    ) -> Result<RequestProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("c", &(parent_window, uri, options))

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -47,7 +47,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use crate::{
     desktop::{HandleToken, DESTINATION, PATH},
-    helpers::{call_basic_response_method, property},
+    helpers::call_basic_response_method,
     Error, WindowIdentifier,
 };
 
@@ -189,10 +189,5 @@ impl<'a> WallpaperProxy<'a> {
             &(parent_window, uri, &options),
         )
         .await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -80,6 +80,7 @@ impl TransferOptions {
 /// will take care of exporting files in the document store as necessary to make
 /// them accessible to the target.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.FileTransfer")]
 pub struct FileTransferProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileTransferProxy<'a> {

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -89,7 +89,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `key` - A key returned by `start_transfer`.
+    /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
     /// * `fds` - A list of file descriptors of the files to register.
     /// * `options` - ?
     /// FIXME: figure out the options we can take here
@@ -115,7 +115,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `key` - A key returned by `start_transfer`.
+    /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
     /// * `options` - ?
     /// FIXME: figure out the options we can take here
     pub async fn retrieve_files(
@@ -150,7 +150,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `key` - A key returned by `start_transfer`.
+    /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
     pub async fn stop_transfer(&self, key: &str) -> Result<(), Error> {
         self.0
             .call_method("StopTransfer", &(key))
@@ -163,7 +163,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// # Returns
     ///
-    /// * The key returned by [`FileTransferProxy::start`]
+    /// * The key returned by [`FileTransferProxy::start_transfer`]
     pub async fn transfer_closed(&self) -> Result<String, Error> {
         let mut stream = self.0.receive_signal("TransferClosed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -11,9 +11,13 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FileTransferProxy::new(&connection).await?;
 //!
-//!     let key = proxy.start_transfer(TransferOptions::default().writeable(true).auto_stop(true)).await?;
+//!     let key = proxy
+//!         .start_transfer(TransferOptions::default().writeable(true).auto_stop(true))
+//!         .await?;
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
-//!     proxy.add_files(&key, &[Fd::from(file.as_raw_fd())], HashMap::new()).await?;
+//!     proxy
+//!         .add_files(&key, &[Fd::from(file.as_raw_fd())], HashMap::new())
+//!         .await?;
 //!
 //!     // The files would be retrieved by another process
 //!     let files = proxy.retrieve_files(&key, HashMap::new()).await?;
@@ -35,12 +39,12 @@ use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a start transfer request.
+/// Specified options for a [`FileTransferProxy::start_transfer`] request.
 pub struct TransferOptions {
     /// Whether to allow the chosen application to write to the files.
     writeable: Option<bool>,
     /// Whether to stop the transfer automatically after the first
-    /// `retrieve_files` call.
+    /// [`FileTransferProxy::retrieve_files`] call.
     #[zvariant(rename = "autostop")]
     auto_stop: Option<bool>,
 }
@@ -53,7 +57,7 @@ impl TransferOptions {
     }
 
     /// Whether to stop the transfer automatically after the first
-    /// retrieve_files call.
+    /// [`FileTransferProxy::retrieve_files`] call.
     pub fn auto_stop(mut self, auto_stop: bool) -> Self {
         self.auto_stop = Some(auto_stop);
         self
@@ -76,6 +80,7 @@ impl TransferOptions {
 pub struct FileTransferProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileTransferProxy<'a> {
+    /// Create a new instance of [`FileTransferProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FileTransferProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.FileTransfer")
@@ -125,7 +130,7 @@ impl<'a> FileTransferProxy<'a> {
         call_method(&self.0, "RetrieveFiles", &(key, options)).await
     }
     /// Starts a session for a file transfer.
-    /// The caller should call `add_files` at least once, to add files to this
+    /// The caller should call [`FileTransferProxy::add_files`] at least once, to add files to this
     /// session.
     ///
     /// # Returns
@@ -136,7 +141,7 @@ impl<'a> FileTransferProxy<'a> {
     }
 
     /// Ends the transfer.
-    /// Further calls to `add_files` or `retrieve_files` for this key will
+    /// Further calls to [`FileTransferProxy::add_files`] or [`FileTransferProxy::retrieve_files`] for this key will
     /// return an error.
     ///
     /// # Arguments

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -95,6 +95,11 @@ impl<'a> FileTransferProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Adds files to a session.
     /// This method can be called multiple times on a given session.
     /// **Note** that only regular files (not directories) can be added.

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -77,6 +77,7 @@ impl TransferOptions {
 /// call RetrieveFiles with the key, to obtain the list of files. The portal
 /// will take care of exporting files in the document store as necessary to make
 /// them accessible to the target.
+#[derive(Debug)]
 pub struct FileTransferProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FileTransferProxy<'a> {

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -26,7 +26,10 @@
 //! ```
 use std::collections::HashMap;
 
-use crate::Error;
+use crate::{
+    helpers::{call_method, property},
+    Error,
+};
 use futures_lite::StreamExt;
 use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
@@ -99,11 +102,7 @@ impl<'a> FileTransferProxy<'a> {
         fds: &[Fd],
         options: HashMap<&str, Value<'_>>,
     ) -> Result<(), Error> {
-        self.0
-            .call_method("AddFiles", &(key, fds, options))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "AddFiles", &(key, fds, options)).await
     }
 
     /// Retrieves files that were previously added to the session with
@@ -123,11 +122,7 @@ impl<'a> FileTransferProxy<'a> {
         key: &str,
         options: HashMap<&str, Value<'_>>,
     ) -> Result<Vec<String>, Error> {
-        self.0
-            .call_method("RetrieveFiles", &(key, options))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "RetrieveFiles", &(key, options)).await
     }
     /// Starts a session for a file transfer.
     /// The caller should call `add_files` at least once, to add files to this
@@ -137,11 +132,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// a key that can be passed to [`FileTransferProxy::retrieve_files`] to obtain the files.
     pub async fn start_transfer(&self, options: TransferOptions) -> Result<String, Error> {
-        self.0
-            .call_method("StartTransfer", &(options))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "StartTransfer", &(options)).await
     }
 
     /// Ends the transfer.
@@ -152,11 +143,7 @@ impl<'a> FileTransferProxy<'a> {
     ///
     /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
     pub async fn stop_transfer(&self, key: &str) -> Result<(), Error> {
-        self.0
-            .call_method("StopTransfer", &(key))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "StopTransfer", &(key)).await
     }
 
     /// Emitted when the transfer is closed.
@@ -172,9 +159,6 @@ impl<'a> FileTransferProxy<'a> {
 
     /// The version of this DBus interface.
     pub async fn version(&self) -> Result<u32, Error> {
-        self.0
-            .get_property::<u32>("version")
-            .await
-            .map_err(From::from)
+        property(&self.0, "version").await
     }
 }

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -34,7 +34,7 @@ use crate::{
     helpers::{call_method, property},
     Error,
 };
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -30,10 +30,7 @@
 //! ```
 use std::collections::HashMap;
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use futures::prelude::stream::*;
 use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
@@ -174,10 +171,5 @@ impl<'a> FileTransferProxy<'a> {
         let mut stream = self.0.receive_signal("TransferClosed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
         message.body::<String>().map_err(From::from)
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -38,6 +38,8 @@ use futures::prelude::stream::*;
 use zvariant::{Fd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
+use super::{DESTINATION, PATH};
+
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
 /// Specified options for a [`FileTransferProxy::start_transfer`] request.
 pub struct TransferOptions {
@@ -85,8 +87,8 @@ impl<'a> FileTransferProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FileTransferProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.FileTransfer")
-            .path("/org/freedesktop/portal/documents")?
-            .destination("org.freedesktop.portal.Documents")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -104,6 +104,7 @@ impl<'a> FileTransferProxy<'a> {
     /// * `fds` - A list of file descriptors of the files to register.
     /// * `options` - ?
     /// FIXME: figure out the options we can take here
+    #[doc(alias = "AddFiles")]
     pub async fn add_files(
         &self,
         key: &str,
@@ -125,6 +126,7 @@ impl<'a> FileTransferProxy<'a> {
     /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
     /// * `options` - ?
     /// FIXME: figure out the options we can take here
+    #[doc(alias = "RetrieveFiles")]
     pub async fn retrieve_files(
         &self,
         key: &str,
@@ -139,6 +141,7 @@ impl<'a> FileTransferProxy<'a> {
     /// # Returns
     ///
     /// a key that can be passed to [`FileTransferProxy::retrieve_files`] to obtain the files.
+    #[doc(alias = "StartTransfer")]
     pub async fn start_transfer(&self, options: TransferOptions) -> Result<String, Error> {
         call_method(&self.0, "StartTransfer", &(options)).await
     }
@@ -150,6 +153,7 @@ impl<'a> FileTransferProxy<'a> {
     /// # Arguments
     ///
     /// * `key` - A key returned by [`FileTransferProxy::start_transfer`].
+    #[doc(alias = "StopTransfer")]
     pub async fn stop_transfer(&self, key: &str) -> Result<(), Error> {
         call_method(&self.0, "StopTransfer", &(key)).await
     }
@@ -159,6 +163,7 @@ impl<'a> FileTransferProxy<'a> {
     /// # Returns
     ///
     /// * The key returned by [`FileTransferProxy::start_transfer`]
+    #[doc(alias = "TransferClosed")]
     pub async fn transfer_closed(&self) -> Result<String, Error> {
         let mut stream = self.0.receive_signal("TransferClosed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -124,6 +124,7 @@ trait Documents {}
 /// `GrantPermissions()`) are reflected in the POSIX mode bits in the fuse
 /// filesystem.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Documents")]
 pub struct DocumentsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DocumentsProxy<'a> {

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -32,6 +32,8 @@
 //!     Ok(())
 //! }
 //! ```
+pub(crate) const DESTINATION: &str = "org.freedesktop.portal.Documents";
+pub(crate) const PATH: &str = "/org/freedesktop/portal/documents";
 
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -129,8 +131,8 @@ impl<'a> DocumentsProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<DocumentsProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Documents")
-            .path("/org/freedesktop/portal/documents")?
-            .destination("org.freedesktop.portal.Documents")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -151,6 +151,7 @@ impl<'a> DocumentsProxy<'a> {
     ///   for the file.
     /// * `persistent` - Whether to add the file only for this session or
     ///   permanently.
+    #[doc(alias = "Add")]
     pub async fn add(
         &self,
         o_path_fd: Fd,
@@ -173,6 +174,7 @@ impl<'a> DocumentsProxy<'a> {
     /// * `flags` - A [`Flags`].
     /// * `app_id` - An application ID, or empty string.
     /// * `permissions` - The permissions to grant.
+    #[doc(alias = "AddFull")]
     pub async fn add_full(
         &self,
         o_path_fds: &[Fd],
@@ -200,6 +202,7 @@ impl<'a> DocumentsProxy<'a> {
     ///   for the file.
     /// * `persistent` - Whether to add the file only for this session or
     ///   permanently.
+    #[doc(alias = "AddNamed")]
     pub async fn add_named(
         &self,
         o_path_parent_fd: Fd,
@@ -229,6 +232,7 @@ impl<'a> DocumentsProxy<'a> {
     /// * `flags` - A [`Flags`].
     /// * `app_id` - An application ID, or empty string.
     /// * `permissions` - The permissions to grant.
+    #[doc(alias = "AddNamedFull")]
     pub async fn add_named_full(
         &self,
         o_path_fd: Fd,
@@ -252,12 +256,15 @@ impl<'a> DocumentsProxy<'a> {
     /// # Arguments
     ///
     /// * `doc_id` - The ID of the file in the document store.
+    #[doc(alias = "Delete")]
     pub async fn delete(&self, doc_id: &str) -> Result<(), Error> {
         call_method(&self.0, "Delete", &(doc_id)).await
     }
 
     /// Returns the path at which the document store fuse filesystem is mounted.
     /// This will typically be /run/user/$UID/doc/.
+    #[doc(alias = "GetMountPoint")]
+    #[doc(alias = "get_mount_point")]
     pub async fn mount_point(&self) -> Result<String, Error> {
         call_method(&self.0, "GetMountPoint", &()).await
     }
@@ -271,6 +278,7 @@ impl<'a> DocumentsProxy<'a> {
     /// * `doc_id` - The ID of the file in the document store.
     /// * `app_id` - The ID of the application to which permissions are granted.
     /// * `permissions` - The permissions to grant.
+    #[doc(alias = "GrantPermissions")]
     pub async fn grant_permissions(
         &self,
         doc_id: &str,
@@ -289,6 +297,7 @@ impl<'a> DocumentsProxy<'a> {
     /// # Arguments
     ///
     /// * `doc_id` - The ID of the file in the document store.
+    #[doc(alias = "Info")]
     pub async fn info(&self, doc_id: &str) -> Result<(String, Permissions), Error> {
         call_method(&self.0, "Info", &(doc_id)).await
     }
@@ -302,6 +311,7 @@ impl<'a> DocumentsProxy<'a> {
     /// # Arguments
     ///
     /// * `app-id` - The application ID, or '' to list all documents.
+    #[doc(alias = "List")]
     pub async fn list(&self, app_id: &str) -> Result<HashMap<String, String>, Error> {
         call_method(&self.0, "List", &(app_id)).await
     }
@@ -315,6 +325,7 @@ impl<'a> DocumentsProxy<'a> {
     /// # Arguments
     ///
     /// - `filename` - A path in the host filesystem.
+    #[doc(alias = "Lookup")]
     pub async fn lookup(&self, filename: &str) -> Result<String, Error> {
         call_method(&self.0, "Lookup", &(filename)).await
     }
@@ -329,6 +340,7 @@ impl<'a> DocumentsProxy<'a> {
     /// * `app_id` - The ID of the application from which permissions are
     ///   revoked.
     /// * `permissions` - The permissions to revoke.
+    #[doc(alias = "RevokePermissions")]
     pub async fn revoke_permissions(
         &self,
         doc_id: &str,

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -1,4 +1,3 @@
-//!
 //! # Examples
 //!
 //! ```rust,no_run
@@ -17,12 +16,16 @@
 //!         }
 //!     }
 //!
-//!     proxy.grant_permissions(
-//!         "f2ee988d",
-//!         "org.mozilla.firefox",
-//!         &[Permission::GrantPermissions],
-//!     ).await?;
-//!     proxy.revoke_permissions("f2ee988d", "org.mozilla.firefox", &[Permission::Write]).await?;
+//!     proxy
+//!         .grant_permissions(
+//!             "f2ee988d",
+//!             "org.mozilla.firefox",
+//!             &[Permission::GrantPermissions],
+//!         )
+//!         .await?;
+//!     proxy
+//!         .revoke_permissions("f2ee988d", "org.mozilla.firefox", &[Permission::Write])
+//!         .await?;
 //!
 //!     proxy.delete("f2ee988d").await?;
 //!
@@ -58,7 +61,7 @@ pub enum Flags {
     ExportDirectory = 8,
 }
 
-/// A `HashMap` mapping application IDs to the permissions for that application
+/// A [`HashMap`] mapping application IDs to the permissions for that application
 pub type Permissions = HashMap<String, Vec<Permission>>;
 
 #[derive(Debug, Clone, AsRefStr, EnumString, IntoStaticStr, ToString, PartialEq, Eq)]
@@ -121,6 +124,7 @@ trait Documents {}
 pub struct DocumentsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DocumentsProxy<'a> {
+    /// Create a new instance of [`DocumentsProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<DocumentsProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Documents")
@@ -163,7 +167,7 @@ impl<'a> DocumentsProxy<'a> {
     /// # Arguments
     ///
     /// * `o_path_fds` - Open file descriptors for the files to export.
-    /// * `flags` - A `Flags`.
+    /// * `flags` - A [`Flags`].
     /// * `app_id` - An application ID, or empty string.
     /// * `permissions` - The permissions to grant.
     pub async fn add_full(
@@ -219,7 +223,7 @@ impl<'a> DocumentsProxy<'a> {
     ///
     /// * `o_path_fd` - Open file descriptor for the parent directory.
     /// * `filename` - The basename for the file.
-    /// * `flags` - A `Flags`.
+    /// * `flags` - A [`Flags`].
     /// * `app_id` - An application ID, or empty string.
     /// * `permissions` - The permissions to grant.
     pub async fn add_named_full(
@@ -289,7 +293,7 @@ impl<'a> DocumentsProxy<'a> {
     /// Lists documents in the document store for an application (or for all
     /// applications).
     ///
-    /// Returns a `HashMap` mapping document IDs to their filesystem path on the
+    /// Returns a [`HashMap`] mapping document IDs to their filesystem path on the
     /// host system
     ///
     /// # Arguments

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -139,6 +139,11 @@ impl<'a> DocumentsProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Adds a file to the document store.
     /// The file is passed in the form of an open file descriptor
     /// to prove that the caller has access to the file.

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -121,6 +121,7 @@ trait Documents {}
 /// The permissions that the application has for a document store entry (see
 /// `GrantPermissions()`) are reflected in the POSIX mode bits in the fuse
 /// filesystem.
+#[derive(Debug)]
 pub struct DocumentsProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> DocumentsProxy<'a> {

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -38,10 +38,7 @@ pub(crate) const PATH: &str = "/org/freedesktop/portal/documents";
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use crate::{
-    helpers::{call_method, property},
-    Error,
-};
+use crate::{helpers::call_method, Error};
 use enumflags2::BitFlags;
 use serde::{de::Deserializer, Deserialize, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -354,11 +351,6 @@ impl<'a> DocumentsProxy<'a> {
         permissions: &[Permission],
     ) -> Result<(), Error> {
         call_method(&self.0, "RevokePermissions", &(doc_id, app_id, permissions)).await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,57 @@
+use crate::request::ResponseError;
+
+#[derive(Debug)]
+pub enum Error {
+    Portal(ResponseError),
+    ZbusFdo(zbus::fdo::Error),
+    Zbus(zbus::Error),
+    Zvariant(zvariant::Error),
+    DBusMalformedMessage(zbus::MessageError),
+    NoResponse,
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Portal(e) => f.write_str(&format!("Portal response error: {}", e)),
+            Self::ZbusFdo(e) => f.write_str(&format!("zbus fdo error: {}", e)),
+            Self::DBusMalformedMessage(e) => {
+                f.write_str(&format!("zbus malformed message error: {}", e))
+            }
+            Self::Zbus(e) => f.write_str(&format!("zbus error: {}", e)),
+            Self::Zvariant(e) => f.write_str(&format!("zvariant error: {}", e)),
+            Self::NoResponse => f.write_str("portal error: no response"),
+        }
+    }
+}
+impl From<ResponseError> for Error {
+    fn from(e: ResponseError) -> Self {
+        Self::Portal(e)
+    }
+}
+
+impl From<zbus::MessageError> for Error {
+    fn from(e: zbus::MessageError) -> Self {
+        Self::DBusMalformedMessage(e)
+    }
+}
+
+impl From<zbus::Error> for Error {
+    fn from(e: zbus::Error) -> Self {
+        Self::Zbus(e)
+    }
+}
+
+impl From<zbus::fdo::Error> for Error {
+    fn from(e: zbus::fdo::Error) -> Self {
+        Self::ZbusFdo(e)
+    }
+}
+
+impl From<zvariant::Error> for Error {
+    fn from(e: zvariant::Error) -> Self {
+        Self::Zvariant(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,19 @@
 use crate::request::ResponseError;
 
 #[derive(Debug)]
+/// The error type for ashpd.
 pub enum Error {
+    /// The portal request didn't succeed.
     Portal(ResponseError),
+    /// A zbus::fdo specific error.
     ZbusFdo(zbus::fdo::Error),
+    /// A zbus specific error.
     Zbus(zbus::Error),
+    /// A conversion error.
     Zvariant(zvariant::Error),
+    /// Failure to parse a response's body.
     DBusMalformedMessage(zbus::MessageError),
+    /// A signal returned no response.
     NoResponse,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::request::ResponseError;
+use crate::desktop::request::ResponseError;
 
 #[derive(Debug)]
 /// The error type for ashpd.

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ pub enum Error {
     DBusMalformedMessage(zbus::MessageError),
     /// A signal returned no response.
     NoResponse,
+    /// Failed to register a game with [`GameModeProxy::register_game`](`crate::desktop::game_mode::GameModeProxy::register_game`).
+    RegisterGameRejected,
+    /// Failed to trash a file, caused by [`TrashProxy::trash_file`](`crate::desktop::trash::TrashProxy::trash_file`).
+    TrashFailed,
 }
 
 impl std::error::Error for Error {}
@@ -30,6 +34,8 @@ impl std::fmt::Display for Error {
             Self::Zbus(e) => f.write_str(&format!("zbus error: {}", e)),
             Self::Zvariant(e) => f.write_str(&format!("zvariant error: {}", e)),
             Self::NoResponse => f.write_str("portal error: no response"),
+            Self::RegisterGameRejected => f.write_str("Failed to register/un-register game mode"),
+            Self::TrashFailed => f.write_str("Failed to trash a file"),
         }
     }
 }

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -28,15 +28,13 @@
 pub(crate) const DESTINATION: &str = "org.freedesktop.portal.Flatpak";
 pub(crate) const PATH: &str = "/org/freedesktop/portal/Flatpak";
 
-use std::collections::HashMap;
-
 use enumflags2::BitFlags;
 use futures::prelude::stream::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::collections::HashMap;
 use zvariant::Fd;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
-use crate::flatpak::update_monitor::UpdateMonitorProxy;
 use crate::{helpers::call_method, Error};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Copy, Clone, BitFlags, Debug, Type)]
@@ -273,4 +271,5 @@ impl<'a> FlatpakProxy<'a> {
 }
 
 /// Monitor if there's an update it and install it.
-pub mod update_monitor;
+mod update_monitor;
+pub use update_monitor::{UpdateInfo, UpdateMonitorProxy, UpdateProgress, UpdateStatus};

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -161,6 +161,7 @@ trait Flatpak {}
 /// The interface exposes some interactions with Flatpak on the host to the
 /// sandbox. For example, it allows you to restart the applications or start a
 /// more sandboxed instance.
+#[derive(Debug)]
 pub struct FlatpakProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FlatpakProxy<'a> {

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -180,6 +180,7 @@ impl<'a> FlatpakProxy<'a> {
     /// Creates an update monitor object that will emit signals
     /// when an update for the caller becomes available, and can be used to
     /// install it.
+    #[doc(alias = "CreateUpdateMonitor")]
     pub async fn create_update_monitor(&self) -> Result<UpdateMonitorProxy<'a>, Error> {
         let options = CreateMonitorOptions::default();
         let path: zvariant::OwnedObjectPath = self
@@ -191,6 +192,7 @@ impl<'a> FlatpakProxy<'a> {
     }
 
     /// Emitted when a process starts by [`FlatpakProxy::spawn`].
+    #[doc(alias = "SpawnStarted")]
     pub async fn receive_spawn_started(&self) -> Result<(u32, u32), Error> {
         let mut stream = self.0.receive_signal("SpawnStarted").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -198,6 +200,7 @@ impl<'a> FlatpakProxy<'a> {
     }
 
     /// Emitted when a process started by [`FlatpakProxy::spawn`] exits.
+    #[doc(alias = "SpawnExited")]
     pub async fn receive_spawn_existed(&self) -> Result<(u32, u32), Error> {
         let mut stream = self.0.receive_signal("SpawnExited").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -219,6 +222,7 @@ impl<'a> FlatpakProxy<'a> {
     ///   process.
     /// * `flags`
     /// * `options` - A [`SpawnOptions`].
+    #[doc(alias = "Spawn")]
     pub async fn spawn(
         &self,
         cwd_path: &str,
@@ -243,6 +247,7 @@ impl<'a> FlatpakProxy<'a> {
     /// * `pid` - The PID of the process to send the signal to.
     /// * `signal` - The signal to send.
     /// * `to_process_group` - Whether to send the signal to the process group.
+    #[doc(alias = "SpawnSignal")]
     pub async fn spawn_signal(
         &self,
         pid: u32,

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -36,7 +36,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::Fd;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
-use crate::{flatpak::update_monitor::UpdateMonitorProxy, helpers::property};
+use crate::flatpak::update_monitor::UpdateMonitorProxy;
 use crate::{helpers::call_method, Error};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Copy, Clone, BitFlags, Debug, Type)]
@@ -265,12 +265,10 @@ impl<'a> FlatpakProxy<'a> {
 
     /// Flags marking what optional features are available.
     pub async fn supports(&self) -> Result<BitFlags<SupportsFlags>, Error> {
-        property(&self.0, "supports").await
-    }
-
-    /// The version of this DBus interface.
-    pub async fn version(&self) -> Result<u32, Error> {
-        property(&self.0, "version").await
+        self.inner()
+            .get_property::<BitFlags<SupportsFlags>>("supports")
+            .await
+            .map_err(From::from)
     }
 }
 

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use enumflags2::BitFlags;
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::Fd;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -11,14 +11,16 @@
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FlatpakProxy::new(&connection).await?;
 //!
-//!     proxy.spawn(
-//!         "contrast".into(),
-//!         &[],
-//!         HashMap::new(),
-//!         HashMap::new(),
-//!         SpawnFlags::ClearEnv | SpawnFlags::NoNetwork,
-//!         SpawnOptions::default(),
-//!     ).await?;
+//!     proxy
+//!         .spawn(
+//!             "contrast".into(),
+//!             &[],
+//!             HashMap::new(),
+//!             HashMap::new(),
+//!             SpawnFlags::ClearEnv | SpawnFlags::NoNetwork,
+//!             SpawnOptions::default(),
+//!         )
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -82,7 +84,7 @@ pub enum SupportsFlags {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a spawn request.
+/// Specified options for a [`FlatpakProxy::spawn`] request.
 pub struct SpawnOptions {
     /// A list of filenames for files inside the sandbox that will be exposed to
     /// the new sandbox, for reading and writing.
@@ -149,7 +151,7 @@ impl SpawnOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on a create monitor request.
+/// Specified options for a [`FlatpakProxy::create_update_monitor`] request.
 ///
 /// Currently there are no possible options yet.
 pub struct CreateMonitorOptions {}
@@ -162,6 +164,7 @@ trait Flatpak {}
 pub struct FlatpakProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FlatpakProxy<'a> {
+    /// Create a new instance of [`FlatpakProxy`].
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FlatpakProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Flatpak")
@@ -216,8 +219,6 @@ impl<'a> FlatpakProxy<'a> {
     ///   process.
     /// * `flags`
     /// * `options` - A [`SpawnOptions`].
-    ///
-    /// [`SpawnOptions`]: ./struct.SpawnOptions.html
     pub async fn spawn(
         &self,
         cwd_path: &str,

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -157,9 +157,7 @@ impl SpawnOptions {
 /// Specified options for a [`FlatpakProxy::create_update_monitor`] request.
 ///
 /// Currently there are no possible options yet.
-pub struct CreateMonitorOptions {}
-
-trait Flatpak {}
+struct CreateMonitorOptions {}
 
 /// The interface exposes some interactions with Flatpak on the host to the
 /// sandbox. For example, it allows you to restart the applications or start a
@@ -182,10 +180,8 @@ impl<'a> FlatpakProxy<'a> {
     /// Creates an update monitor object that will emit signals
     /// when an update for the caller becomes available, and can be used to
     /// install it.
-    pub async fn create_update_monitor(
-        &self,
-        options: CreateMonitorOptions,
-    ) -> Result<UpdateMonitorProxy<'a>, Error> {
+    pub async fn create_update_monitor(&self) -> Result<UpdateMonitorProxy<'a>, Error> {
+        let options = CreateMonitorOptions::default();
         let path: zvariant::OwnedObjectPath = self
             .0
             .call_method("CreateUpdateMonitor", &(options))

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -185,7 +185,7 @@ impl<'a> FlatpakProxy<'a> {
     ) -> Result<UpdateMonitorProxy<'a>, Error> {
         let path: zvariant::OwnedObjectPath = self
             .0
-            .call_method("CreateUpdateMonitors", &(options))
+            .call_method("CreateUpdateMonitor", &(options))
             .await?
             .body()?;
         UpdateMonitorProxy::new(self.0.connection(), path.into_inner()).await

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -25,6 +25,9 @@
 //!     Ok(())
 //! }
 //! ```
+pub(crate) const DESTINATION: &str = "org.freedesktop.portal.Flatpak";
+pub(crate) const PATH: &str = "/org/freedesktop/portal/Flatpak";
+
 use std::collections::HashMap;
 
 use enumflags2::BitFlags;
@@ -169,8 +172,8 @@ impl<'a> FlatpakProxy<'a> {
     pub async fn new(connection: &zbus::azync::Connection) -> Result<FlatpakProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.Flatpak")
-            .path("/org/freedesktop/portal/Flatpak")?
-            .destination("org.freedesktop.portal.Flatpak")
+            .path(PATH)?
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -178,6 +178,11 @@ impl<'a> FlatpakProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// Creates an update monitor object that will emit signals
     /// when an update for the caller becomes available, and can be used to
     /// install it.

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -163,6 +163,7 @@ struct CreateMonitorOptions {}
 /// sandbox. For example, it allows you to restart the applications or start a
 /// more sandboxed instance.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Flatpak")]
 pub struct FlatpakProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> FlatpakProxy<'a> {

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -102,6 +102,7 @@ impl<'a> UpdateMonitorProxy<'a> {
     }
 
     /// A signal received when there's progress during the application update.
+    #[doc(alias = "Progress")]
     pub async fn receive_progress(&self) -> Result<UpdateProgress, Error> {
         let mut stream = self.0.receive_signal("Progress").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -109,6 +110,7 @@ impl<'a> UpdateMonitorProxy<'a> {
     }
 
     /// A signal received when there's an application update.
+    #[doc(alias = "UpdateAvailable")]
     pub async fn receive_update_available(&self) -> Result<UpdateInfo, Error> {
         let mut stream = self.0.receive_signal("UpdateAvailable").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
@@ -119,12 +121,14 @@ impl<'a> UpdateMonitorProxy<'a> {
     ///
     /// **Note** that updates are only allowed if the new version
     /// has the same permissions (or less) than the currently installed version.
+    #[doc(alias = "Update")]
     pub async fn update(&self, parent_window: WindowIdentifier) -> Result<(), Error> {
         let options = UpdateOptions::default();
         call_method(&self.0, "Update", &(parent_window, options)).await
     }
 
     /// Ends the update monitoring and cancels any ongoing installation.
+    #[doc(alias = "Close")]
     pub async fn close(&self) -> Result<(), Error> {
         call_method(&self.0, "Close", &()).await
     }

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -3,7 +3,7 @@
 //! How to monitor if there's a new update and install it.
 //! Only available for Flatpak applications.
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use ashpd::flatpak::update_monitor::{
 //!     UpdateInfo, UpdateMonitorProxy, UpdateOptions, UpdateProgress,
 //! };

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -29,7 +29,7 @@
 //! }
 //! ```
 use crate::{helpers::call_method, Error, WindowIdentifier};
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::ObjectPath;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -4,20 +4,24 @@
 //! Only available for Flatpak applications.
 //!
 //! ```rust,no_run
-//! use ashpd::flatpak::update_monitor::{
-//!     UpdateInfo, UpdateMonitorProxy, UpdateOptions, UpdateProgress,
+//! use ashpd::flatpak::{
+//!     update_monitor::{UpdateInfo, UpdateMonitorProxy, UpdateOptions, UpdateProgress},
+//!     CreateMonitorOptions, FlatpakProxy,
 //! };
-//! use ashpd::flatpak::{CreateMonitorOptions, FlatpakProxy};
 //! use ashpd::WindowIdentifier;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FlatpakProxy::new(&connection).await?;
 //!
-//!     let monitor = proxy.create_update_monitor(CreateMonitorOptions::default()).await?;
+//!     let monitor = proxy
+//!         .create_update_monitor(CreateMonitorOptions::default())
+//!         .await?;
 //!     let info = monitor.receive_update_available().await?;
 //!
-//!     monitor.update(WindowIdentifier::default(), UpdateOptions::default()).await?;
+//!     monitor
+//!         .update(WindowIdentifier::default(), UpdateOptions::default())
+//!         .await?;
 //!     let progress = monitor.receive_progress().await?;
 //!     println!("{:#?}", progress);
 //!
@@ -31,7 +35,7 @@ use zvariant::ObjectPath;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
-/// Specified options on an update request.
+/// Specified options for a [`UpdateMonitorProxy::update`] request.
 ///
 /// Currently there are no possible options yet.
 pub struct UpdateOptions {}
@@ -88,6 +92,9 @@ pub struct UpdateProgress {
 pub struct UpdateMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> UpdateMonitorProxy<'a> {
+    /// Create a new instance of [`UpdateMonitorProxy`].
+    ///
+    /// **Note** A [`UpdateMonitorProxy`] is not supposed to be created manually.
     pub async fn new(
         connection: &zbus::azync::Connection,
         path: ObjectPath<'a>,

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -89,6 +89,7 @@ pub struct UpdateProgress {
 /// The interface exposes some interactions with Flatpak on the host to the
 /// sandbox. For example, it allows you to restart the applications or start a
 /// more sandboxed instance.
+#[derive(Debug)]
 pub struct UpdateMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> UpdateMonitorProxy<'a> {

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -24,10 +24,10 @@
 //!     Ok(())
 //! }
 //! ```
-use crate::{Error, WindowIdentifier};
+use crate::{helpers::call_method, Error, WindowIdentifier};
 use futures_lite::StreamExt;
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use zvariant::OwnedObjectPath;
+use zvariant::ObjectPath;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
@@ -90,7 +90,7 @@ pub struct UpdateMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 impl<'a> UpdateMonitorProxy<'a> {
     pub async fn new(
         connection: &zbus::azync::Connection,
-        path: OwnedObjectPath,
+        path: ObjectPath<'a>,
     ) -> Result<UpdateMonitorProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
             .interface("org.freedesktop.portal.UpdateMonitor")
@@ -124,19 +124,11 @@ impl<'a> UpdateMonitorProxy<'a> {
         parent_window: WindowIdentifier,
         options: UpdateOptions,
     ) -> Result<(), Error> {
-        self.0
-            .call_method("Update", &(parent_window, options))
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "Update", &(parent_window, options)).await
     }
 
     /// Ends the update monitoring and cancels any ongoing installation.
     pub async fn close(&self) -> Result<(), Error> {
-        self.0
-            .call_method("Close", &())
-            .await?
-            .body()
-            .map_err(From::from)
+        call_method(&self.0, "Close", &()).await
     }
 }

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -4,24 +4,16 @@
 //! Only available for Flatpak applications.
 //!
 //! ```rust,no_run
-//! use ashpd::flatpak::{
-//!     update_monitor::{UpdateInfo, UpdateMonitorProxy, UpdateOptions, UpdateProgress},
-//!     CreateMonitorOptions, FlatpakProxy,
-//! };
-//! use ashpd::WindowIdentifier;
+//! use ashpd::flatpak::FlatpakProxy;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = FlatpakProxy::new(&connection).await?;
 //!
-//!     let monitor = proxy
-//!         .create_update_monitor(CreateMonitorOptions::default())
-//!         .await?;
+//!     let monitor = proxy.create_update_monitor().await?;
 //!     let info = monitor.receive_update_available().await?;
 //!
-//!     monitor
-//!         .update(WindowIdentifier::default(), UpdateOptions::default())
-//!         .await?;
+//!     monitor.update(Default::default()).await?;
 //!     let progress = monitor.receive_progress().await?;
 //!     println!("{:#?}", progress);
 //!
@@ -38,7 +30,7 @@ use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 /// Specified options for a [`UpdateMonitorProxy::update`] request.
 ///
 /// Currently there are no possible options yet.
-pub struct UpdateOptions {}
+struct UpdateOptions {}
 
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug)]
 /// A response containing the update information when an update is available.
@@ -127,11 +119,8 @@ impl<'a> UpdateMonitorProxy<'a> {
     ///
     /// **Note** that updates are only allowed if the new version
     /// has the same permissions (or less) than the currently installed version.
-    pub async fn update(
-        &self,
-        parent_window: WindowIdentifier,
-        options: UpdateOptions,
-    ) -> Result<(), Error> {
+    pub async fn update(&self, parent_window: WindowIdentifier) -> Result<(), Error> {
+        let options = UpdateOptions::default();
         call_method(&self.0, "Update", &(parent_window, options)).await
     }
 

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -26,6 +26,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use zvariant::ObjectPath;
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
+use super::DESTINATION;
+
 #[derive(SerializeDict, DeserializeDict, TypeDict, Debug, Default)]
 /// Specified options for a [`UpdateMonitorProxy::update`] request.
 ///
@@ -82,6 +84,7 @@ pub struct UpdateProgress {
 /// sandbox. For example, it allows you to restart the applications or start a
 /// more sandboxed instance.
 #[derive(Debug)]
+#[doc(alias = "org.freedesktop.portal.Flatpak.UpdateMonitor")]
 pub struct UpdateMonitorProxy<'a>(zbus::azync::Proxy<'a>);
 
 impl<'a> UpdateMonitorProxy<'a> {
@@ -93,9 +96,9 @@ impl<'a> UpdateMonitorProxy<'a> {
         path: ObjectPath<'a>,
     ) -> Result<UpdateMonitorProxy<'a>, Error> {
         let proxy = zbus::ProxyBuilder::new_bare(connection)
-            .interface("org.freedesktop.portal.UpdateMonitor")
+            .interface("org.freedesktop.portal.Flatpak.UpdateMonitor")
             .path(path)?
-            .destination("org.freedesktop.portal.Flatpak.UpdateMonitor")
+            .destination(DESTINATION)
             .build_async()
             .await?;
         Ok(Self(proxy))

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -130,9 +130,9 @@ impl<'a> UpdateMonitorProxy<'a> {
     /// **Note** that updates are only allowed if the new version
     /// has the same permissions (or less) than the currently installed version.
     #[doc(alias = "Update")]
-    pub async fn update(&self, parent_window: WindowIdentifier) -> Result<(), Error> {
+    pub async fn update(&self, identifier: WindowIdentifier) -> Result<(), Error> {
         let options = UpdateOptions::default();
-        call_method(&self.0, "Update", &(parent_window, options)).await
+        call_method(&self.0, "Update", &(identifier, options)).await
     }
 
     /// Ends the update monitoring and cancels any ongoing installation.

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -104,6 +104,11 @@ impl<'a> UpdateMonitorProxy<'a> {
         Ok(Self(proxy))
     }
 
+    /// Get a reference to the underlying Proxy.
+    pub fn inner(&self) -> &zbus::azync::Proxy<'_> {
+        &self.0
+    }
+
     /// A signal received when there's progress during the application update.
     #[doc(alias = "Progress")]
     pub async fn receive_progress(&self) -> Result<UpdateProgress, Error> {

--- a/src/handle_token.rs
+++ b/src/handle_token.rs
@@ -1,6 +1,8 @@
-use std::convert::TryFrom;
-
+use core::fmt;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, fmt::Display};
 use zvariant_derive::Type;
 
 /// A handle token is a DBus Object Path element, specified in the
@@ -23,6 +25,24 @@ use zvariant_derive::Type;
 /// ```
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, Type)]
 pub struct HandleToken(String);
+
+impl Display for HandleToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Default for HandleToken {
+    fn default() -> Self {
+        let mut rng = thread_rng();
+        let token: String = (&mut rng)
+            .sample_iter(Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect();
+        HandleToken::try_from(token).unwrap()
+    }
+}
 
 #[derive(Debug)]
 pub struct HandleInvalidCharacter(char);

--- a/src/handle_token.rs
+++ b/src/handle_token.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zvariant_derive::Type;
 
 /// A handle token is a DBus Object Path element, specified in the
-/// [`RequestProxy`] or [`SessionProxy`] object path following this format
+/// `RequestProxy` or [`SessionProxy`](crate::session::SessionProxy) object path following this format
 /// `/org/freedesktop/portal/desktop/request/SENDER/TOKEN` where sender is the
 /// caller's unique name and token is the HandleToken.
 ///
@@ -21,9 +21,6 @@ use zvariant_derive::Type;
 ///
 /// assert_eq!(HandleToken::try_from("تجربة").is_ok(), false);
 /// ```
-///
-/// [`SessionProxy`]: ./struct.SessionProxy.html
-/// [`RequestProxy`]: ./struct.RequestProxy.html
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, Type)]
 pub struct HandleToken(String);
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,61 @@
+use std::convert::TryFrom;
+
+use crate::request::{BasicResponse, RequestProxy};
+use crate::Error;
+use zvariant::OwnedValue;
+
+pub(crate) async fn call_request_method<R>(
+    proxy: &zbus::azync::Proxy<'_>,
+    method_name: &str,
+    body: &(impl serde::ser::Serialize + zvariant::Type),
+) -> Result<R, Error>
+where
+    R: serde::de::DeserializeOwned + zvariant::Type,
+{
+    let message = proxy.call_method(method_name, body).await?;
+    let path: zvariant::OwnedObjectPath = message.body()?;
+    let request = RequestProxy::new(proxy.connection(), path.into_inner()).await?;
+    let response = request.receive_response::<R>().await?;
+    Ok(response)
+}
+
+pub(crate) async fn call_basic_response_method(
+    proxy: &zbus::azync::Proxy<'_>,
+    method_name: &str,
+    body: &(impl serde::ser::Serialize + zvariant::Type),
+) -> Result<(), Error> {
+    let message = proxy.call_method(method_name, body).await?;
+    let path: zvariant::OwnedObjectPath = message.body()?;
+
+    let request = RequestProxy::new(proxy.connection(), path.into_inner()).await?;
+    request.receive_response::<BasicResponse>().await?;
+    Ok(())
+}
+
+pub(crate) async fn call_method<R>(
+    proxy: &zbus::azync::Proxy<'_>,
+    method_name: &str,
+    body: &(impl serde::ser::Serialize + zvariant::Type),
+) -> Result<R, Error>
+where
+    R: serde::de::DeserializeOwned + zvariant::Type,
+{
+    proxy
+        .call_method(method_name, body)
+        .await?
+        .body::<R>()
+        .map_err(From::from)
+}
+
+pub(crate) async fn property<R>(
+    proxy: &zbus::azync::Proxy<'_>,
+    property_name: &str,
+) -> Result<R, Error>
+where
+    R: serde::de::DeserializeOwned + zvariant::Type + TryFrom<OwnedValue>,
+{
+    proxy
+        .get_property::<R>(property_name)
+        .await
+        .map_err(From::from)
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Debug};
 
 use crate::request::{BasicResponse, RequestProxy};
 use crate::Error;
@@ -7,39 +7,54 @@ use zvariant::OwnedValue;
 pub(crate) async fn call_request_method<R>(
     proxy: &zbus::azync::Proxy<'_>,
     method_name: &str,
-    body: &(impl serde::ser::Serialize + zvariant::Type),
+    body: &(impl serde::ser::Serialize + zvariant::Type + Debug),
 ) -> Result<R, Error>
 where
-    R: serde::de::DeserializeOwned + zvariant::Type,
+    R: serde::de::DeserializeOwned + zvariant::Type + Debug,
 {
+    println!(
+        "calling request method {} with body {:#?}",
+        method_name, body
+    );
     let message = proxy.call_method(method_name, body).await?;
     let path: zvariant::OwnedObjectPath = message.body()?;
+    println!("received path {:#?}", path);
     let request = RequestProxy::new(proxy.connection(), path.into_inner()).await?;
+    println!("created request {:#?}", request);
     let response = request.receive_response::<R>().await?;
+    println!("received response {:#?}", response);
     Ok(response)
 }
 
 pub(crate) async fn call_basic_response_method(
     proxy: &zbus::azync::Proxy<'_>,
     method_name: &str,
-    body: &(impl serde::ser::Serialize + zvariant::Type),
+    body: &(impl serde::ser::Serialize + zvariant::Type + Debug),
 ) -> Result<(), Error> {
+    println!(
+        "calling casic response method {} with body {:#?}",
+        method_name, body
+    );
     let message = proxy.call_method(method_name, body).await?;
     let path: zvariant::OwnedObjectPath = message.body()?;
+    println!("received path {:#?}", path);
 
     let request = RequestProxy::new(proxy.connection(), path.into_inner()).await?;
-    request.receive_response::<BasicResponse>().await?;
+    println!("created request {:#?}", request);
+    let response = request.receive_response::<BasicResponse>().await?;
+    println!("received response {:#?}", response);
     Ok(())
 }
 
 pub(crate) async fn call_method<R>(
     proxy: &zbus::azync::Proxy<'_>,
     method_name: &str,
-    body: &(impl serde::ser::Serialize + zvariant::Type),
+    body: &(impl serde::ser::Serialize + zvariant::Type + Debug),
 ) -> Result<R, Error>
 where
     R: serde::de::DeserializeOwned + zvariant::Type,
 {
+    println!("calling method {} with body {:#?}", method_name, body);
     proxy
         .call_method(method_name, body)
         .await?

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,8 +1,8 @@
-use crate::Error;
-use crate::{
+use crate::desktop::{
     request::{BasicResponse, RequestProxy},
     HandleToken,
 };
+use crate::Error;
 use futures::TryFutureExt;
 use std::{convert::TryFrom, fmt::Debug};
 use zvariant::OwnedValue;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,8 +4,7 @@ use crate::desktop::{
 };
 use crate::Error;
 use futures::TryFutureExt;
-use std::{convert::TryFrom, fmt::Debug};
-use zvariant::OwnedValue;
+use std::fmt::Debug;
 
 pub(crate) async fn call_request_method<R, B>(
     proxy: &zbus::azync::Proxy<'_>,
@@ -53,19 +52,6 @@ where
 {
     proxy
         .call::<B, R>(method_name, body)
-        .await
-        .map_err(From::from)
-}
-
-pub(crate) async fn property<R>(
-    proxy: &zbus::azync::Proxy<'_>,
-    property_name: &str,
-) -> Result<R, Error>
-where
-    R: serde::de::DeserializeOwned + zvariant::Type + TryFrom<OwnedValue>,
-{
-    proxy
-        .get_property::<R>(property_name)
         .await
         .map_err(From::from)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! | feature_gtk3 | Implement `From<Color>` for `gdk3::RGBA` |
 //! |  | Implement `From<gtk3::Window>` for [`WindowIdentifier`] |
 //! | feature_gtk4 | Implement `From<Color>` for `gdk4::RGBA` |
-//! |  | Provides [`WindowIdentifier::from_window`] |
+//! |  | Provides `WindowIdentifier::from_window` |
 #[cfg(all(all(feature = "feature_gtk3", feature = "feature_gtk4"), not(doc)))]
 compile_error!("You can't enable both GTK 3 & GTK 4 features at once");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,16 @@
 //!
 //! Ask the compositor to pick a color
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot, WindowIdentifier};
+//! use ashpd::{desktop::screenshot::{ScreenshotProxy, PickColorOptions}, WindowIdentifier};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
-//!     let color = screenshot::pick_color(identifier).await?;
+//!     let connection = zbus::azync::Connection::new_session().await?;
+//!
+//!     let proxy = ScreenshotProxy::new(&connection).await?;
+//!     let color = proxy.pick_color(identifier, PickColorOptions::default()).await?;
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
+//!
 //!     Ok(())
 //! }
 //! ```
@@ -56,6 +60,7 @@ mod error;
 /// received an update & install it.
 pub mod flatpak;
 mod handle_token;
+mod helpers;
 mod request;
 mod session;
 mod window_identifier;
@@ -72,6 +77,5 @@ pub fn is_sandboxed() -> bool {
 
 pub use self::error::Error;
 pub use self::handle_token::HandleToken;
-pub use self::request::{BasicResponse, RequestProxy, ResponseError};
 pub use self::session::SessionProxy;
 pub use self::window_identifier::WindowIdentifier;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //!     let proxy = ScreenshotProxy::new(&connection).await?;
 //!     let color = proxy
-//!         .pick_color(Default::default())
+//!         .pick_color(identifier, PickColorOptions::default())
 //!         .await?;
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,14 @@
 //!
 //! Ask the compositor to pick a color
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::{PickColorOptions, ScreenshotProxy}, WindowIdentifier};
+//! use ashpd::desktop::screenshot::ScreenshotProxy;
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
-//!     let identifier = WindowIdentifier::default();
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = ScreenshotProxy::new(&connection).await?;
-//!     let color = proxy
-//!         .pick_color(identifier, PickColorOptions::default())
-//!         .await?;
+//!     let color = proxy.pick_color(Default::default()).await?;
+//!
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
 //!
 //!     Ok(())
@@ -28,16 +26,15 @@
 //!
 //! Start a PipeWire stream from the user's camera
 //! ```rust,no_run
-//! use std::collections::HashMap;
-//! use ashpd::desktop::camera::{CameraAccessOptions, CameraProxy};
+//! use ashpd::desktop::camera::CameraProxy;
 //!
 //! pub async fn run() -> Result<(), ashpd::Error> {
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!     let proxy = CameraProxy::new(&connection).await?;
 //!     if proxy.is_camera_present().await? {
-//!         proxy.access_camera(CameraAccessOptions::default()).await?;
+//!         proxy.access_camera().await?;
 //!
-//!         let remote_fd = proxy.open_pipe_wire_remote(HashMap::new()).await?;
+//!         let remote_fd = proxy.open_pipe_wire_remote().await?;
 //!         // pass the remote fd to GStreamer for example
 //!     }
 //!     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(broken_intra_doc_links)]
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 //! ASHPD, acronym of Aperture Science Handheld Portal Device is a Rust & [zbus](https://gitlab.freedesktop.org/zeenix/zbus) wrapper of
 //! the XDG portals DBus interfaces. The library aims to provide an easy way to
 //! interact with the various portals defined per the [specifications](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html).
@@ -10,14 +10,19 @@
 //!
 //! Ask the compositor to pick a color
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::{ScreenshotProxy, PickColorOptions}, WindowIdentifier};
+//! use ashpd::{
+//!     desktop::screenshot::{PickColorOptions, ScreenshotProxy},
+//!     WindowIdentifier,
+//! };
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
 //!     let connection = zbus::azync::Connection::new_session().await?;
 //!
 //!     let proxy = ScreenshotProxy::new(&connection).await?;
-//!     let color = proxy.pick_color(identifier, PickColorOptions::default()).await?;
+//!     let color = proxy
+//!         .pick_color(Default::default())
+//!         .await?;
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
 //!
 //!     Ok(())
@@ -26,13 +31,18 @@
 //!
 //! Start a PipeWire stream from the user's camera
 //! ```rust,no_run
-//! use ashpd::{desktop::camera, WindowIdentifier};
+//! use std::collections::HashMap;
+//! use ashpd::desktop::camera::{CameraAccessOptions, CameraProxy};
 //!
-//! async fn run() -> Result<(), ashpd::Error> {
-//!     let identifier = WindowIdentifier::default();
-//!     let pipewire_fd = camera::stream().await?;
-//!     // Render the stream with GStreamer for example, see the demo
+//! pub async fn run() -> Result<(), ashpd::Error> {
+//!     let connection = zbus::azync::Connection::new_session().await?;
+//!     let proxy = CameraProxy::new(&connection).await?;
+//!     if proxy.is_camera_present().await? {
+//!         proxy.access_camera(CameraAccessOptions::default()).await?;
 //!
+//!         let remote_fd = proxy.open_pipe_wire_remote(HashMap::new()).await?;
+//!         // pass the remote fd to GStreamer for example
+//!     }
 //!     Ok(())
 //! }
 //! ```
@@ -77,5 +87,6 @@ pub fn is_sandboxed() -> bool {
 
 pub use self::error::Error;
 pub use self::handle_token::HandleToken;
+pub use self::request::ResponseError;
 pub use self::session::SessionProxy;
 pub use self::window_identifier::WindowIdentifier;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! | Feature | Description |
 //! | ---     | ----------- |
 //! | feature_gtk3 | Implement `From<Color>` for `gdk3::RGBA` |
-//! |  | Implement `From<gtk3::Window>` for [`WindowIdentifier`] |
+//! |  | Provides `WindowIdentifier::from_window` |
 //! | feature_gtk4 | Implement `From<Color>` for `gdk4::RGBA` |
 //! |  | Provides `WindowIdentifier::from_window` |
 #[cfg(all(all(feature = "feature_gtk3", feature = "feature_gtk4"), not(doc)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(broken_intra_doc_links)]
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 //! ASHPD, acronym of Aperture Science Handheld Portal Device is a Rust & [zbus](https://gitlab.freedesktop.org/zeenix/zbus) wrapper of
 //! the XDG portals DBus interfaces. The library aims to provide an easy way to
 //! interact with the various portals defined per the [specifications](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html).
@@ -10,30 +10,25 @@
 //!
 //! Ask the compositor to pick a color
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot, Response, WindowIdentifier};
-//! use zbus::fdo::Result;
+//! use ashpd::{desktop::screenshot, WindowIdentifier};
 //!
-//! async fn run() -> Result<()> {
+//! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
-//!     if let Response::Ok(color) = screenshot::pick_color(identifier).await? {
-//!         println!("({}, {}, {})", color.red(), color.green(), color.blue());
-//!     }
+//!     let color = screenshot::pick_color(identifier).await?;
+//!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
 //!     Ok(())
 //! }
 //! ```
 //!
 //! Start a PipeWire stream from the user's camera
 //! ```rust,no_run
-//! use ashpd::{desktop::camera, Response, WindowIdentifier};
-//! use zbus::fdo::Result;
+//! use ashpd::{desktop::camera, WindowIdentifier};
 //!
-//! async fn run() -> Result<()> {
+//! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
-//!     if camera::is_present().await? {
-//!         if let Response::Ok(pipewire_fd) = camera::stream().await? {
-//!             // Render the stream with GStreamer for example, see the demo
-//!         }
-//!     }
+//!     let pipewire_fd = camera::stream().await?;
+//!     // Render the stream with GStreamer for example, see the demo
+//!
 //!     Ok(())
 //! }
 //! ```
@@ -56,6 +51,7 @@ compile_error!("You can't enable both GTK 3 & GTK 4 features at once");
 pub mod desktop;
 /// Interact with the documents store or transfer files across apps.
 pub mod documents;
+mod error;
 /// Spawn commands outside the sandbox or monitor if the running application has
 /// received an update & install it.
 pub mod flatpak;
@@ -74,7 +70,8 @@ pub fn is_sandboxed() -> bool {
     std::path::Path::new("/.flatpak-info").exists()
 }
 
+pub use self::error::Error;
 pub use self::handle_token::HandleToken;
-pub use self::request::{AsyncRequestProxy, BasicResponse, RequestProxy, Response, ResponseError};
-pub use self::session::{AsyncSessionProxy, SessionProxy};
+pub use self::request::{BasicResponse, RequestProxy, ResponseError};
+pub use self::session::SessionProxy;
 pub use self::window_identifier::WindowIdentifier;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,7 @@
 //!
 //! Ask the compositor to pick a color
 //! ```rust,no_run
-//! use ashpd::{
-//!     desktop::screenshot::{PickColorOptions, ScreenshotProxy},
-//!     WindowIdentifier,
-//! };
+//! use ashpd::{desktop::screenshot::{PickColorOptions, ScreenshotProxy}, WindowIdentifier};
 //!
 //! async fn run() -> Result<(), ashpd::Error> {
 //!     let identifier = WindowIdentifier::default();
@@ -66,14 +63,12 @@ pub mod desktop;
 /// Interact with the documents store or transfer files across apps.
 pub mod documents;
 mod error;
+mod window_identifier;
+pub use self::window_identifier::WindowIdentifier;
 /// Spawn commands outside the sandbox or monitor if the running application has
 /// received an update & install it.
 pub mod flatpak;
-mod handle_token;
 mod helpers;
-mod request;
-mod session;
-mod window_identifier;
 pub use enumflags2;
 pub use zbus;
 pub use zvariant;
@@ -86,7 +81,3 @@ pub fn is_sandboxed() -> bool {
 }
 
 pub use self::error::Error;
-pub use self::handle_token::HandleToken;
-pub use self::request::ResponseError;
-pub use self::session::SessionProxy;
-pub use self::window_identifier::WindowIdentifier;

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,10 +10,8 @@ use zvariant_derive::Type;
 
 use crate::helpers::call_method;
 
-/// A typical response returned by the `connect_response` signal of a
-/// `RequestProxy`.
-///
-/// [`RequestProxy`]: ./struct.RequestProxy.html
+/// A typical response returned by the [`RequestProxy::receive_response`] signal of a
+/// [`RequestProxy`].
 #[derive(Debug)]
 pub(crate) enum Response<T>
 where

--- a/src/request.rs
+++ b/src/request.rs
@@ -172,7 +172,7 @@ impl From<ResponseError> for ResponseType {
 /// what it expected, and update its signal subscription if it isn't.
 /// This ensures that applications will work with both old and new versions of
 /// xdg-desktop-portal.
-pub struct RequestProxy<'a>(zbus::azync::Proxy<'a>);
+pub struct RequestProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> RequestProxy<'a> {
     pub async fn new(
@@ -185,7 +185,7 @@ impl<'a> RequestProxy<'a> {
             .destination("org.freedesktop.portal.Desktop")
             .build_async()
             .await?;
-        Ok(Self(proxy))
+        Ok(Self(proxy, connection.clone()))
     }
 
     pub async fn receive_response<R>(&self) -> Result<R, crate::Error>

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{
     de::{self, DeserializeOwned, Error, Visitor},
     Deserialize, Deserializer, Serialize,

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,7 +29,7 @@ pub type SessionDetails = HashMap<String, OwnedValue>;
 ///
 /// A client who started a session vanishing from the D-Bus is equivalent to
 /// closing all active sessions made by said client.
-pub struct SessionProxy<'a>(zbus::azync::Proxy<'a>);
+pub struct SessionProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> SessionProxy<'a> {
     pub async fn new(
@@ -42,7 +42,7 @@ impl<'a> SessionProxy<'a> {
             .destination("org.freedesktop.portal.Desktop")
             .build_async()
             .await?;
-        Ok(Self(proxy))
+        Ok(Self(proxy, connection.clone()))
     }
 
     pub async fn receive_closed(&self) -> Result<SessionDetails, Error> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,7 @@ use crate::{
     helpers::{call_method, property},
     Error,
 };
-use futures_lite::StreamExt;
+use futures::prelude::stream::*;
 use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use zvariant::{ObjectPath, OwnedValue, Signature};

--- a/src/session.rs
+++ b/src/session.rs
@@ -32,6 +32,7 @@ pub type SessionDetails = HashMap<String, OwnedValue>;
 ///
 /// A client who started a session vanishing from the D-Bus is equivalent to
 /// closing all active sessions made by said client.
+#[derive(Debug)]
 pub struct SessionProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> SessionProxy<'a> {
@@ -53,6 +54,7 @@ impl<'a> SessionProxy<'a> {
 
     /// Emitted when a session is closed.
     pub async fn receive_closed(&self) -> Result<SessionDetails, Error> {
+        println!("session got closed {}", self.0.path());
         let mut stream = self.0.receive_signal("Closed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;
         message.body::<SessionDetails>().map_err(From::from)

--- a/src/session.rs
+++ b/src/session.rs
@@ -35,6 +35,9 @@ pub type SessionDetails = HashMap<String, OwnedValue>;
 pub struct SessionProxy<'a>(zbus::azync::Proxy<'a>, zbus::azync::Connection);
 
 impl<'a> SessionProxy<'a> {
+    /// Create a new instance of [`SessionProxy`].
+    ///
+    /// **Note** A [`SessionProxy`] is not supposed to be created manually.
     pub async fn new(
         connection: &zbus::azync::Connection,
         path: ObjectPath<'a>,
@@ -48,6 +51,7 @@ impl<'a> SessionProxy<'a> {
         Ok(Self(proxy, connection.clone()))
     }
 
+    /// Emitted when a session is closed.
     pub async fn receive_closed(&self) -> Result<SessionDetails, Error> {
         let mut stream = self.0.receive_signal("Closed").await?;
         let message = stream.next().await.ok_or(Error::NoResponse)?;

--- a/src/window_identifier.rs
+++ b/src/window_identifier.rs
@@ -25,6 +25,7 @@ use serde::{ser::Serializer, Serialize};
 pub enum WindowIdentifier {
     /// Gtk 4 Window Identifier
     #[cfg(feature = "feature_gtk4")]
+    #[doc(hidden)]
     Gtk4 {
         /// The top level window
         root: gtk4::Root,
@@ -33,11 +34,13 @@ pub enum WindowIdentifier {
     },
     /// GTK 3 Window Identifier
     #[cfg(feature = "feature_gtk3")]
+    #[doc(hidden)]
     Gtk3 {
         /// The exported window handle
         handle: String,
     },
     /// For Other Toolkits
+    #[doc(hidden)]
     Other(String),
 }
 

--- a/src/window_identifier.rs
+++ b/src/window_identifier.rs
@@ -13,15 +13,13 @@ use serde::{ser::Serializer, Serialize};
 /// xdg-foreign protocol.
 ///
 /// For other windowing systems, or if you don't have a suitable handle, just
-/// use the `Default` implementation.
+/// use the [`Default`] implementation.
 ///
 /// Please **note** that the `From<gtk3::Window>` implementation is x11 only for
 /// now.
 ///
 /// We would love merge requests that adds other `From<T> for WindowIdentifier`
 /// implementations for other toolkits.
-///
-/// [`WindowIdentifier`]: ./struct.WindowIdentifier.html
 pub enum WindowIdentifier {
     /// Gtk 4 Window Identifier
     #[cfg(feature = "feature_gtk4")]
@@ -109,7 +107,7 @@ impl From<gtk3::Window> for WindowIdentifier {
 
 impl WindowIdentifier {
     #[cfg(feature = "feature_gtk4")]
-    /// Creates a `WindowIdentifier` from a [`gtk::Root`](https://gnome.pages.gitlab.gnome.org/gtk/gtk4/iface.Root.html).
+    /// Creates a [`WindowIdentifier`] from a [`gtk::Root`](https://gnome.pages.gitlab.gnome.org/gtk/gtk4/iface.Root.html).
     /// `gtk::Root` is the interface implemented by all the widgets that can act
     /// as a top level widget.
     ///


### PR DESCRIPTION
The very first step in this MR is to manually rewrite all the Proxies instead of using the dbus_proxy proc macro. The reasoning is a bunch of generated Proxies are not really ideal and we let the user deal with a very not clean API.

With this we also dropped completely the sync API and we only export the Async one.

Before this can be merged:
- [x] Update the demo according to the changes made to ashpd
- [x] Update the docs/tests per the API changes
- [x] Enjoy :tada: