### PR TITLE
Use OwnedFd instead of Fd for returned file descriptors from zbus

### DIFF
--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -18,10 +18,10 @@
 
 use std::{
     collections::HashMap,
-    os::unix::prelude::{AsRawFd, RawFd},
+    os::unix::prelude::{IntoRawFd, RawFd},
 };
 
-use zvariant::{Fd, Value};
+use zvariant::{OwnedFd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, TypeDict};
 
 use super::{HandleToken, DESTINATION, PATH};
@@ -89,8 +89,8 @@ impl<'a> CameraProxy<'a> {
         // `options` parameter doesn't seems to be used yet
         // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/camera.c#L178
         let options: HashMap<&str, Value<'_>> = HashMap::new();
-        let fd: Fd = call_method(&self.0, "OpenPipeWireRemote", &(options)).await?;
-        Ok(fd.as_raw_fd())
+        let fd: OwnedFd = call_method(&self.0, "OpenPipeWireRemote", &(options)).await?;
+        Ok(fd.into_raw_fd())
     }
 
     /// A boolean stating whether there is any cameras available.

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -37,14 +37,14 @@
 use std::{
     collections::HashMap,
     fmt::Debug,
-    os::unix::prelude::{AsRawFd, RawFd},
+    os::unix::prelude::{IntoRawFd, RawFd},
 };
 
 use enumflags2::BitFlags;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use zvariant::{Fd, Value};
+use zvariant::{OwnedFd, Value};
 use zvariant_derive::{DeserializeDict, SerializeDict, Type, TypeDict};
 
 use super::{HandleToken, SessionProxy, DESTINATION, PATH};
@@ -261,8 +261,8 @@ impl<'a> ScreenCastProxy<'a> {
         // `options` parameter doesn't seems to be used yet
         // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/screen-cast.c#L812
         let options: HashMap<&str, Value<'_>> = HashMap::new();
-        let fd: Fd = call_method(&self.0, "OpenPipeWireRemote", &(session, options)).await?;
-        Ok(fd.as_raw_fd())
+        let fd: OwnedFd = call_method(&self.0, "OpenPipeWireRemote", &(session, options)).await?;
+        Ok(fd.into_raw_fd())
     }
 
     /// Configure what the screen cast session should record.


### PR DESCRIPTION
`zbus` now closes file descriptors when the message is destroyed, unless if you use `OwnedFd`.