### PR TITLE
window identifier: provide a way API around raw-window-handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ feature_gtk3 = ["gdk3x11", "gdk3wayland", "gtk3"]
 feature_gtk4 = ["gdk4x11", "gdk4wayland", "gtk4"]
 feature_pipewire = ["pw", "libc"]
 log = ["tracing"]
+raw_handle = ["raw-window-handle"]
 
 [dependencies]
 enumflags2 = "0.7"
@@ -36,3 +37,4 @@ zbus = "2.0.0"
 futures = "0.3"
 tracing = {version = "0.1", optional = true}
 libc = {version = "0.2.94", optional = true}
+raw-window-handle = {version = "0.4", optional = true}

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ pub async fn run() -> ashpd::Result<()> {
 | feature_gtk4 | Implement `From<Color>` for [`gdk4::RGBA`](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gdk4/struct.RGBA.html) |
 |  | Provides `WindowIdentifier::from_native` that takes a [`IsA<gtk4::Native>`](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/struct.Native.html) |
 | feature_pipewire | Provides `ashpd::desktop::camera::pipewire_node_id` that helps you retrieve the PipeWire Node ID to use with the file descriptor returned by the camera portal |
+| raw_handle | Implement `From<WindowIdentifier>` for [raw-window-handle](https://lib.rs/crates/raw-window-handle) crate |


### PR DESCRIPTION
Fixes #40 

Still needs an API to get a Window Identifier from a RawWindowHandle.  Also needs a new release of gdk3wayland to expose the ffi crate