### PR TITLE
Relax bounds for AsRef<Path>.

### DIFF
--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -305,7 +305,7 @@ impl SaveFileOptions {
 
     /// Sets the current folder.
     #[must_use]
-    pub fn current_folder(mut self, current_folder: impl AsRef<Path> + Type + Serialize) -> Self {
+    pub fn current_folder(mut self, current_folder: impl AsRef<Path>) -> Self {
         let cstr = CString::new(current_folder.as_ref().as_os_str().as_bytes())
             .expect("`current_folder` should not be null terminated");
         self.current_folder = Some(cstr.into_bytes_with_nul());
@@ -314,7 +314,7 @@ impl SaveFileOptions {
 
     /// Sets the absolute path of the file.
     #[must_use]
-    pub fn current_file(mut self, current_file: impl AsRef<Path> + Type + Serialize) -> Self {
+    pub fn current_file(mut self, current_file: impl AsRef<Path>) -> Self {
         let cstr = CString::new(current_file.as_ref().as_os_str().as_bytes())
             .expect("`current_file` should not be null terminated");
         self.current_file = Some(cstr.into_bytes_with_nul());
@@ -392,7 +392,7 @@ impl SaveFilesOptions {
 
     /// Specifies the current folder path.
     #[must_use]
-    pub fn current_folder(mut self, current_folder: impl AsRef<Path> + Type + Serialize) -> Self {
+    pub fn current_folder(mut self, current_folder: impl AsRef<Path>) -> Self {
         let cstr = CString::new(current_folder.as_ref().as_os_str().as_bytes())
             .expect("`current_folder` should not be null terminated");
         self.current_folder = Some(cstr.into_bytes_with_nul());
@@ -401,7 +401,7 @@ impl SaveFilesOptions {
 
     /// Sets a list of files to save.
     #[must_use]
-    pub fn files(mut self, files: &[impl AsRef<Path> + Type + Serialize]) -> Self {
+    pub fn files(mut self, files: &[impl AsRef<Path>]) -> Self {
         self.files = Some(
             files
                 .iter()

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -301,7 +301,7 @@ impl<'a> DocumentsProxy<'a> {
     pub async fn add_named(
         &self,
         o_path_parent_fd: &(impl AsRawFd + fmt::Debug),
-        filename: (impl AsRef<Path> + Serialize + Type + fmt::Debug),
+        filename: impl AsRef<Path>,
         reuse_existing: bool,
         persistent: bool,
     ) -> Result<OwnedDocumentID, Error> {
@@ -343,7 +343,7 @@ impl<'a> DocumentsProxy<'a> {
     pub async fn add_named_full(
         &self,
         o_path_fd: &(impl AsRawFd + fmt::Debug),
-        filename: (impl AsRef<Path> + Serialize + Type + fmt::Debug),
+        filename: impl AsRef<Path>,
         flags: BitFlags<Flags>,
         app_id: ApplicationID<'_>,
         permissions: &[Permission],
@@ -501,7 +501,7 @@ impl<'a> DocumentsProxy<'a> {
     #[doc(alias = "Lookup")]
     pub async fn lookup(
         &self,
-        filename: (impl AsRef<Path> + Serialize + Type + fmt::Debug),
+        filename: impl AsRef<Path>,
     ) -> Result<Option<OwnedDocumentID>, Error> {
         let cstr = CString::new(filename.as_ref().as_os_str().as_bytes())
             .expect("`filename` should not be null terminated");

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -314,8 +314,8 @@ impl<'a> FlatpakProxy<'a> {
     #[doc(alias = "xdp_portal_spawn")]
     pub async fn spawn(
         &self,
-        cwd_path: (impl AsRef<Path> + Type + Serialize + Debug),
-        argv: &[impl AsRef<Path> + Type + Serialize + Debug],
+        cwd_path: impl AsRef<Path>,
+        argv: &[impl AsRef<Path>],
         fds: HashMap<u32, Fd>,
         envs: HashMap<&str, &str>,
         flags: BitFlags<SpawnFlags>,


### PR DESCRIPTION
I think the `Type` and `Serialize` parts of the `AsRef<Path> + Type + Serialize` weren't needed, because the path just gets turned into a byte slice anyway (which implements `Type` and `Serialize`).