### PR TITLE
Update pipewire to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ gdk4wayland = {package = "gdk4-wayland", version = "0.4", optional = true}
 gdk4x11 = {package = "gdk4-x11", version = "0.4", optional = true}
 gtk4 = {version = "0.4", optional = true}
 
-pw = {package= "pipewire", version = "0.4", optional = true}
+pw = {package= "pipewire", version = "0.5", optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_repr = "0.1"
 rand = {version = "0.8", default-features = false}


### PR DESCRIPTION
Should let ashpd build on 32-bit architectures with glibc and gets it closer to building on 32-bit architectures with musl.