### PR TITLE
Drop the Proxy suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ It provides an alternative to the C library [https://github.com/flatpak/libporta
 Ask the compositor to pick a color
 
 ```rust,no_run
-use ashpd::desktop::screenshot::ScreenshotProxy;
+use ashpd::desktop::screenshot::Screenshot;
 use ashpd::WindowIdentifier;
 
 async fn run() -> ashpd::Result<()> {
-    let proxy = ScreenshotProxy::new().await?;
+    let proxy = Screenshot::new().await?;
     let color = proxy.pick_color(&WindowIdentifier::default()).await?;
     println!("({}, {}, {})", color.red(), color.green(), color.blue());
     Ok(())
@@ -26,10 +26,10 @@ async fn run() -> ashpd::Result<()> {
 Start a PipeWire stream from the user's camera
 
 ```rust,no_run
-use ashpd::desktop::camera::CameraProxy;
+use ashpd::desktop::camera::Camera;
 
 pub async fn run() -> ashpd::Result<()> {
-    let proxy = CameraProxy::new().await?;
+    let proxy = Camera::new().await?;
     if proxy.is_camera_present().await? {
         proxy.access_camera().await?;
         let remote_fd = proxy.open_pipe_wire_remote().await?;

--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -20,10 +20,10 @@
 //! Or by using the Proxy directly
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::account::AccountProxy, WindowIdentifier};
+//! use ashpd::{desktop::account::Account, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = AccountProxy::new().await?;
+//!     let proxy = Account::new().await?;
 //!     let user_info = proxy
 //!         .user_information(
 //!             &WindowIdentifier::default(),
@@ -47,7 +47,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Clone, Debug, Default)]
-/// Specified options for a [`AccountProxy::user_information`] request.
+/// Specified options for a [`Account::user_information`] request.
 #[zvariant(signature = "dict")]
 struct UserInfoOptions {
     /// A string that will be used as the last element of the handle.
@@ -65,7 +65,7 @@ impl UserInfoOptions {
 }
 
 #[derive(Debug, SerializeDict, DeserializeDict, Clone, Type)]
-/// The response of a [`AccountProxy::user_information`] request.
+/// The response of a [`Account::user_information`] request.
 #[zvariant(signature = "dict")]
 pub struct UserInfo {
     /// User identifier.
@@ -102,11 +102,11 @@ impl UserInfo {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Account`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Account).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Account")]
-pub struct AccountProxy<'a>(zbus::Proxy<'a>);
+pub struct Account<'a>(zbus::Proxy<'a>);
 
-impl<'a> AccountProxy<'a> {
-    /// Create a new instance of [`AccountProxy`].
-    pub async fn new() -> Result<AccountProxy<'a>, Error> {
+impl<'a> Account<'a> {
+    /// Create a new instance of [`Account`].
+    pub async fn new() -> Result<Account<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Account")?
@@ -147,11 +147,11 @@ impl<'a> AccountProxy<'a> {
 
 #[doc(alias = "xdp_portal_get_user_information")]
 #[doc(alias = "get_user_information")]
-/// A handy wrapper around [`AccountProxy::user_information`].
+/// A handy wrapper around [`Account::user_information`].
 pub async fn user_information(
     identifier: &WindowIdentifier,
     reason: &str,
 ) -> Result<UserInfo, Error> {
-    let proxy = AccountProxy::new().await?;
+    let proxy = Account::new().await?;
     proxy.user_information(identifier, reason).await
 }

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -55,7 +55,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Clone, Default)]
-/// Specified options for a [`BackgroundProxy::request_background`] request.
+/// Specified options for a [`Background::request_background`] request.
 #[zvariant(signature = "dict")]
 struct BackgroundOptions {
     /// A string that will be used as the last element of the handle.
@@ -103,16 +103,16 @@ impl BackgroundOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug)]
-/// The response of a [`BackgroundProxy::request_background`] request.
+/// The response of a [`Background::request_background`] request.
 #[zvariant(signature = "dict")]
-pub struct Background {
+pub struct Response {
     /// If the application is allowed to run in the background.
     background: bool,
     /// If the application is will be auto-started.
     autostart: bool,
 }
 
-impl Background {
+impl Response {
     /// If the application is allowed to run in the background.
     pub fn run_in_background(&self) -> bool {
         self.background
@@ -131,11 +131,11 @@ impl Background {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Background`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Background).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Background")]
-pub struct BackgroundProxy<'a>(zbus::Proxy<'a>);
+pub struct Background<'a>(zbus::Proxy<'a>);
 
-impl<'a> BackgroundProxy<'a> {
-    /// Create a new instance of [`BackgroundProxy`].
-    pub async fn new() -> Result<BackgroundProxy<'a>, Error> {
+impl<'a> Background<'a> {
+    /// Create a new instance of [`Background`].
+    pub async fn new() -> Result<Background<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Background")?
@@ -175,7 +175,7 @@ impl<'a> BackgroundProxy<'a> {
         auto_start: bool,
         command_line: Option<&[impl AsRef<str> + Type + Serialize]>,
         dbus_activatable: bool,
-    ) -> Result<Background, Error> {
+    ) -> Result<Response, Error> {
         let options = BackgroundOptions::default()
             .reason(reason)
             .autostart(auto_start)
@@ -192,15 +192,15 @@ impl<'a> BackgroundProxy<'a> {
 }
 
 #[doc(alias = "xdp_portal_request_background")]
-/// A handy wrapper around [`BackgroundProxy::request_background`].
+/// A handy wrapper around [`Background::request_background`].
 pub async fn request(
     identifier: &WindowIdentifier,
     reason: &str,
     auto_start: bool,
     command_line: Option<&[impl AsRef<str> + Type + Serialize]>,
     dbus_activatable: bool,
-) -> Result<Background, Error> {
-    let proxy = BackgroundProxy::new().await?;
+) -> Result<Response, Error> {
+    let proxy = Background::new().await?;
     proxy
         .request_background(
             identifier,

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -1,10 +1,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::camera::CameraProxy;
+//! use ashpd::desktop::camera::Camera;
 //!
 //! pub async fn run() -> ashpd::Result<()> {
-//!     let proxy = CameraProxy::new().await?;
+//!     let proxy = Camera::new().await?;
 //!     if proxy.is_camera_present().await? {
 //!         proxy.access_camera().await?;
 //!
@@ -29,7 +29,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Clone, Debug, Default)]
-/// Specified options for a [`CameraProxy::access_camera`] request.
+/// Specified options for a [`Camera::access_camera`] request.
 #[zvariant(signature = "dict")]
 struct CameraAccessOptions {
     /// A string that will be used as the last element of the handle.
@@ -42,11 +42,11 @@ struct CameraAccessOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Camera`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Camera).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Camera")]
-pub struct CameraProxy<'a>(zbus::Proxy<'a>);
+pub struct Camera<'a>(zbus::Proxy<'a>);
 
-impl<'a> CameraProxy<'a> {
-    /// Create a new instance of [`CameraProxy`].
-    pub async fn new() -> Result<CameraProxy<'a>, Error> {
+impl<'a> Camera<'a> {
+    /// Create a new instance of [`Camera`].
+    pub async fn new() -> Result<Camera<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Camera")?
@@ -116,7 +116,7 @@ impl<'a> CameraProxy<'a> {
 }
 
 /// A helper to get the PipeWire Node ID to use with the camera file descriptor
-/// returned by [`CameraProxy::open_pipe_wire_remote`].
+/// returned by [`Camera::open_pipe_wire_remote`].
 ///
 /// Currently, the camera portal only gives us a file descriptor. Not passing a
 /// node id may cause the media session controller to auto-connect the client to

--- a/src/desktop/dynamic_launcher.rs
+++ b/src/desktop/dynamic_launcher.rs
@@ -3,14 +3,14 @@
 //! ```rust,no_run
 //! use ashpd::{
 //!     desktop::{
-//!         dynamic_launcher::{DynamicLauncherProxy, LauncherType, PrepareInstallOptions},
+//!         dynamic_launcher::{DynamicLauncher, LauncherType, PrepareInstallOptions},
 //!         Icon,
 //!     },
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = DynamicLauncherProxy::new().await?;
+//!     let proxy = DynamicLauncher::new().await?;
 //!     let (name, token) = proxy
 //!         .prepare_install(
 //!             &WindowIdentifier::default(),
@@ -139,11 +139,11 @@ impl PrepareInstallOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.DynamicLauncher`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.DynamicLauncher).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.DynamicLauncher")]
-pub struct DynamicLauncherProxy<'a>(zbus::Proxy<'a>);
+pub struct DynamicLauncher<'a>(zbus::Proxy<'a>);
 
-impl<'a> DynamicLauncherProxy<'a> {
-    /// Create a new instance of [`DynamicLauncherProxy`].
-    pub async fn new() -> Result<DynamicLauncherProxy<'a>, Error> {
+impl<'a> DynamicLauncher<'a> {
+    /// Create a new instance of [`DynamicLauncher`].
+    pub async fn new() -> Result<DynamicLauncher<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.DynamicLauncher")?

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -4,12 +4,12 @@
 //!
 //! ```rust,no_run
 //! use ashpd::{
-//!     desktop::file_chooser::{Choice, FileChooserProxy, FileFilter, OpenFileOptions},
+//!     desktop::file_chooser::{Choice, FileChooser, FileFilter, OpenFileOptions},
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FileChooserProxy::new().await?;
+//!     let proxy = FileChooser::new().await?;
 //!     let files = proxy
 //!         .open_file(
 //!             &WindowIdentifier::default(),
@@ -39,12 +39,12 @@
 //!
 //! ```rust,no_run
 //! use ashpd::{
-//!     desktop::file_chooser::{FileChooserProxy, FileFilter, SaveFileOptions},
+//!     desktop::file_chooser::{FileChooser, FileFilter, SaveFileOptions},
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FileChooserProxy::new().await?;
+//!     let proxy = FileChooser::new().await?;
 //!     let files = proxy
 //!         .save_file(
 //!             &WindowIdentifier::default(),
@@ -67,12 +67,12 @@
 //!
 //! ```rust,no_run
 //! use ashpd::{
-//!     desktop::file_chooser::{FileChooserProxy, SaveFilesOptions},
+//!     desktop::file_chooser::{FileChooser, SaveFilesOptions},
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FileChooserProxy::new().await?;
+//!     let proxy = FileChooser::new().await?;
 //!     let files = proxy
 //!         .save_files(
 //!             &WindowIdentifier::default(),
@@ -196,7 +196,7 @@ impl Choice {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Clone, Debug, Default)]
-/// Specified options for a [`FileChooserProxy::open_file`] request.
+/// Specified options for a [`FileChooser::open_file`] request.
 #[zvariant(signature = "dict")]
 pub struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
@@ -269,7 +269,7 @@ impl OpenFileOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`FileChooserProxy::save_file`] request.
+/// Specified options for a [`FileChooser::save_file`] request.
 #[zvariant(signature = "dict")]
 pub struct SaveFileOptions {
     /// A string that will be used as the last element of the handle.
@@ -355,7 +355,7 @@ impl SaveFileOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`FileChooserProxy::save_files`] request.
+/// Specified options for a [`FileChooser::save_files`] request.
 #[zvariant(signature = "dict")]
 pub struct SaveFilesOptions {
     /// A string that will be used as the last element of the handle.
@@ -422,8 +422,8 @@ impl SaveFilesOptions {
 
 #[derive(Debug, Type, SerializeDict, Clone, DeserializeDict)]
 /// A response to a
-/// [`FileChooserProxy::open_file`]/[`FileChooserProxy::save_file`]/
-/// [`FileChooserProxy::save_files`] request.
+/// [`FileChooser::open_file`]/[`FileChooser::save_file`]/
+/// [`FileChooser::save_files`] request.
 #[zvariant(signature = "dict")]
 pub struct SelectedFiles {
     uris: Vec<String>,
@@ -449,11 +449,11 @@ impl SelectedFiles {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.FileChooser`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.FileChooser).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.FileChooser")]
-pub struct FileChooserProxy<'a>(zbus::Proxy<'a>);
+pub struct FileChooser<'a>(zbus::Proxy<'a>);
 
-impl<'a> FileChooserProxy<'a> {
-    /// Create a new instance of [`FileChooserProxy`].
-    pub async fn new() -> Result<FileChooserProxy<'a>, Error> {
+impl<'a> FileChooser<'a> {
+    /// Create a new instance of [`FileChooser`].
+    pub async fn new() -> Result<FileChooser<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.FileChooser")?

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -1,10 +1,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::game_mode::GameModeProxy;
+//! use ashpd::desktop::game_mode::GameMode;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = GameModeProxy::new().await?;
+//!     let proxy = GameMode::new().await?;
 //!
 //!     println!("{:#?}", proxy.register_game(246612).await?);
 //!     println!("{:#?}", proxy.query_status(246612).await?);
@@ -69,19 +69,19 @@ enum RegisterStatus {
 /// this is necessary.
 ///
 /// Note: GameMode will monitor active clients, i.e. games and other programs
-/// that have successfully called [`GameModeProxy::register_game`]. In the event
+/// that have successfully called [`GameMode::register_game`]. In the event
 /// that a client terminates without a call to the
-/// [`GameModeProxy::unregister_game`] method, GameMode will automatically
+/// [`GameMode::unregister_game`] method, GameMode will automatically
 /// un-register the client. This might happen with a (small) delay.
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.GameMode`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.GameMode).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.GameMode")]
-pub struct GameModeProxy<'a>(zbus::Proxy<'a>);
+pub struct GameMode<'a>(zbus::Proxy<'a>);
 
-impl<'a> GameModeProxy<'a> {
-    /// Create a new instance of [`GameModeProxy`].
-    pub async fn new() -> Result<GameModeProxy<'a>, Error> {
+impl<'a> GameMode<'a> {
+    /// Create a new instance of [`GameMode`].
+    pub async fn new() -> Result<GameMode<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.GameMode")?

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zbus::zvariant::{DeserializeDict, OwnedObjectPath, SerializeDict, Type};
 
-use super::{HandleToken, SessionProxy, DESTINATION, PATH};
+use super::{HandleToken, Session, DESTINATION, PATH};
 use crate::{
     helpers::{
         call_basic_response_method, call_method, call_request_method, receive_signal,
@@ -193,13 +193,13 @@ impl<'a> InhibitProxy<'a> {
     pub async fn create_monitor(
         &self,
         identifier: &WindowIdentifier,
-    ) -> Result<SessionProxy<'a>, Error> {
+    ) -> Result<Session<'a>, Error> {
         let options = CreateMonitorOptions::default();
         let body = &(&identifier, &options);
-        let (monitor, proxy): (CreateMonitor, SessionProxy) = futures::try_join!(
+        let (monitor, proxy): (CreateMonitor, Session) = futures::try_join!(
             call_request_method(self.inner(), &options.handle_token, "CreateMonitor", body)
                 .into_future(),
-            SessionProxy::from_unique_name(&options.session_handle_token).into_future(),
+            Session::from_unique_name(&options.session_handle_token).into_future(),
         )?;
         assert_eq!(proxy.inner().path().as_str(), &monitor.session_handle);
         Ok(proxy)
@@ -252,7 +252,7 @@ impl<'a> InhibitProxy<'a> {
     ///
     /// # Arguments
     ///
-    /// * `session` - A [`SessionProxy`], created with
+    /// * `session` - A [`Session`], created with
     ///   [`create_monitor()`][`InhibitProxy::create_monitor`].
     ///
     /// # Specifications
@@ -260,7 +260,7 @@ impl<'a> InhibitProxy<'a> {
     /// See also [`QueryEndResponse`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-signal-org-freedesktop-portal-Inhibit.QueryEndResponse).
     #[doc(alias = "QueryEndResponse")]
     #[doc(alias = "xdp_portal_session_monitor_query_end_response")]
-    pub async fn query_end_response(&self, session: &SessionProxy<'_>) -> Result<(), Error> {
+    pub async fn query_end_response(&self, session: &Session<'_>) -> Result<(), Error> {
         call_method(self.inner(), "QueryEndResponse", &(session)).await
     }
 }

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -1,10 +1,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::memory_monitor::MemoryMonitorProxy;
+//! use ashpd::desktop::memory_monitor::MemoryMonitor;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = MemoryMonitorProxy::new().await?;
+//!     let proxy = MemoryMonitor::new().await?;
 //!
 //!     let level = proxy.receive_low_memory_warning().await?;
 //!     println!("{}", level);
@@ -26,11 +26,11 @@ use crate::{
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.MemoryMonitor`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.MemoryMonitor).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.MemoryMonitor")]
-pub struct MemoryMonitorProxy<'a>(zbus::Proxy<'a>);
+pub struct MemoryMonitor<'a>(zbus::Proxy<'a>);
 
-impl<'a> MemoryMonitorProxy<'a> {
-    /// Create a new instance of [`MemoryMonitorProxy`].
-    pub async fn new() -> Result<MemoryMonitorProxy<'a>, Error> {
+impl<'a> MemoryMonitor<'a> {
+    /// Create a new instance of [`MemoryMonitor`].
+    pub async fn new() -> Result<MemoryMonitor<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.MemoryMonitor")?

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -5,7 +5,7 @@ mod handle_token;
 pub(crate) mod request;
 mod session;
 pub(crate) use self::handle_token::HandleToken;
-pub use self::{request::ResponseError, session::SessionProxy};
+pub use self::{request::ResponseError, session::Session};
 
 /// Request access to the current logged user information such as the id, name
 /// or their avatar uri.

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -2,10 +2,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::network_monitor::NetworkMonitorProxy;
+//! use ashpd::desktop::network_monitor::NetworkMonitor;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = NetworkMonitorProxy::new().await?;
+//!     let proxy = NetworkMonitor::new().await?;
 //!
 //!     println!("{}", proxy.can_reach("www.google.com", 80).await?);
 //!     println!("{}", proxy.is_available().await?);
@@ -88,11 +88,11 @@ impl fmt::Display for Connectivity {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.NetworkMonitor`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.NetworkMonitor).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.NetworkMonitor")]
-pub struct NetworkMonitorProxy<'a>(zbus::Proxy<'a>);
+pub struct NetworkMonitor<'a>(zbus::Proxy<'a>);
 
-impl<'a> NetworkMonitorProxy<'a> {
-    /// Create a new instance of [`NetworkMonitorProxy`].
-    pub async fn new() -> Result<NetworkMonitorProxy<'a>, Error> {
+impl<'a> NetworkMonitor<'a> {
+    /// Create a new instance of [`NetworkMonitor`].
+    pub async fn new() -> Result<NetworkMonitor<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.NetworkMonitor")?

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -4,13 +4,13 @@
 //! use std::{thread, time};
 //!
 //! use ashpd::desktop::{
-//!     notification::{Action, Button, Notification, NotificationProxy, Priority},
+//!     notification::{Action, Button, Notification, Notifications, Priority},
 //!     Icon,
 //! };
 //! use zbus::zvariant::Value;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = NotificationProxy::new().await?;
+//!     let proxy = Notifications::new().await?;
 //!
 //!     let notification_id = "org.gnome.design.Contrast";
 //!     proxy
@@ -284,11 +284,11 @@ impl Action {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Notification`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Notification).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Notification")]
-pub struct NotificationProxy<'a>(zbus::Proxy<'a>);
+pub struct Notifications<'a>(zbus::Proxy<'a>);
 
-impl<'a> NotificationProxy<'a> {
-    /// Create a new instance of [`NotificationProxy`].
-    pub async fn new() -> Result<NotificationProxy<'a>, Error> {
+impl<'a> Notifications<'a> {
+    /// Create a new instance of [`Notifications`].
+    pub async fn new() -> Result<Notifications<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Notification")?

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -19,12 +19,12 @@
 //! ```rust,no_run
 //! use std::fs::File;
 //!
-//! use ashpd::{desktop::open_uri::OpenURIProxy, WindowIdentifier};
+//! use ashpd::{desktop::open_uri::OpenURI, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
 //!
-//!     let proxy = OpenURIProxy::new().await?;
+//!     let proxy = OpenURI::new().await?;
 //!
 //!     proxy
 //!         .open_file(&WindowIdentifier::default(), &file, false, true)
@@ -52,12 +52,12 @@
 //! ```rust,no_run
 //! use std::fs::File;
 //!
-//! use ashpd::{desktop::open_uri::OpenURIProxy, WindowIdentifier};
+//! use ashpd::{desktop::open_uri::OpenURI, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
 //!     let directory = File::open("/home/bilelmoussaoui/Downloads").unwrap();
 //!
-//!     let proxy = OpenURIProxy::new().await?;
+//!     let proxy = OpenURI::new().await?;
 //!
 //!     proxy
 //!         .open_directory(&WindowIdentifier::default(), &directory)
@@ -82,10 +82,10 @@
 //! Or by using the Proxy directly
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::open_uri::OpenURIProxy, WindowIdentifier};
+//! use ashpd::{desktop::open_uri::OpenURI, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = OpenURIProxy::new().await?;
+//!     let proxy = OpenURI::new().await?;
 //!     let uri = "https://github.com/bilelmoussaoui/ashpd";
 //!
 //!     proxy
@@ -106,7 +106,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`OpenURIProxy::open_directory`] request.
+/// Specified options for a [`OpenURI::open_directory`] request.
 #[zvariant(signature = "dict")]
 struct OpenDirOptions {
     /// A string that will be used as the last element of the handle.
@@ -123,8 +123,8 @@ impl OpenDirOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`OpenURIProxy::open_file`] or
-/// [`OpenURIProxy::open_uri`] request.
+/// Specified options for a [`OpenURI::open_file`] or
+/// [`OpenURI::open_uri`] request.
 #[zvariant(signature = "dict")]
 struct OpenFileOptions {
     /// A string that will be used as the last element of the handle.
@@ -167,11 +167,11 @@ impl OpenFileOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.OpenURI`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.OpenURI).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.OpenURI")]
-pub struct OpenURIProxy<'a>(zbus::Proxy<'a>);
+pub struct OpenURI<'a>(zbus::Proxy<'a>);
 
-impl<'a> OpenURIProxy<'a> {
-    /// Create a new instance of [`OpenURIProxy`].
-    pub async fn new() -> Result<OpenURIProxy<'a>, Error> {
+impl<'a> OpenURI<'a> {
+    /// Create a new instance of [`OpenURI`].
+    pub async fn new() -> Result<OpenURI<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.OpenURI")?
@@ -282,37 +282,37 @@ impl<'a> OpenURIProxy<'a> {
 }
 
 #[doc(alias = "xdp_portal_open_uri")]
-/// A handy wrapper around [`OpenURIProxy::open_uri`].
+/// A handy wrapper around [`OpenURI::open_uri`].
 pub async fn open_uri(
     identifier: &WindowIdentifier,
     uri: &str,
     writeable: bool,
     ask: bool,
 ) -> Result<(), Error> {
-    let proxy = OpenURIProxy::new().await?;
+    let proxy = OpenURI::new().await?;
     proxy.open_uri(identifier, uri, writeable, ask).await?;
     Ok(())
 }
 
-/// A handy wrapper around [`OpenURIProxy::open_file`].
+/// A handy wrapper around [`OpenURI::open_file`].
 pub async fn open_file(
     identifier: &WindowIdentifier,
     file: &impl AsRawFd,
     writeable: bool,
     ask: bool,
 ) -> Result<(), Error> {
-    let proxy = OpenURIProxy::new().await?;
+    let proxy = OpenURI::new().await?;
     proxy.open_file(identifier, file, writeable, ask).await?;
     Ok(())
 }
 
 #[doc(alias = "xdp_portal_open_directory")]
-/// A handy wrapper around [`OpenURIProxy::open_directory`].
+/// A handy wrapper around [`OpenURI::open_directory`].
 pub async fn open_directory(
     identifier: &WindowIdentifier,
     directory: &impl AsRawFd,
 ) -> Result<(), Error> {
-    let proxy = OpenURIProxy::new().await?;
+    let proxy = OpenURI::new().await?;
     proxy.open_directory(identifier, directory).await?;
     Ok(())
 }

--- a/src/desktop/power_profile_monitor.rs
+++ b/src/desktop/power_profile_monitor.rs
@@ -10,11 +10,11 @@ use crate::{helpers::session_connection, Error};
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.PowerProfileMonitor`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.PowerProfileMonitor).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.PowerProfileMonitor")]
-pub struct PowerProfileMonitorProxy<'a>(zbus::Proxy<'a>);
+pub struct PowerProfileMonitor<'a>(zbus::Proxy<'a>);
 
-impl<'a> PowerProfileMonitorProxy<'a> {
-    /// Create a new instance of [`PowerProfileMonitorProxy`].
-    pub async fn new() -> Result<PowerProfileMonitorProxy<'a>, Error> {
+impl<'a> PowerProfileMonitor<'a> {
+    /// Create a new instance of [`PowerProfileMonitor`].
+    pub async fn new() -> Result<PowerProfileMonitor<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.PowerProfileMonitor")?

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -5,10 +5,10 @@
 //! ```rust,no_run
 //! use std::fs::File;
 //!
-//! use ashpd::{desktop::print::PrintProxy, WindowIdentifier};
+//! use ashpd::{desktop::print::Print, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = PrintProxy::new().await?;
+//!     let proxy = Print::new().await?;
 //!     let identifier = WindowIdentifier::default();
 //!
 //!     let file =
@@ -548,7 +548,7 @@ impl PageSetup {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`PrintProxy::prepare_print`] request.
+/// Specified options for a [`Print::prepare_print`] request.
 #[zvariant(signature = "dict")]
 struct PreparePrintOptions {
     /// A string that will be used as the last element of the handle.
@@ -566,20 +566,20 @@ impl PreparePrintOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`PrintProxy::print`] request.
+/// Specified options for a [`Print::print`] request.
 #[zvariant(signature = "dict")]
 struct PrintOptions {
     /// A string that will be used as the last element of the handle.
     handle_token: HandleToken,
     /// Whether to make the dialog modal.
     modal: Option<bool>,
-    /// Token that was returned by a previous [`PrintProxy::prepare_print`]
+    /// Token that was returned by a previous [`Print::prepare_print`]
     /// call.
     token: Option<u32>,
 }
 
 impl PrintOptions {
-    /// A token retrieved from [`PrintProxy::prepare_print`].
+    /// A token retrieved from [`Print::prepare_print`].
     pub fn token(mut self, token: u32) -> Self {
         self.token = Some(token);
         self
@@ -593,7 +593,7 @@ impl PrintOptions {
 }
 
 #[derive(DeserializeDict, SerializeDict, Type, Debug)]
-/// A response to a [`PrintProxy::prepare_print`] request.
+/// A response to a [`Print::prepare_print`] request.
 #[zvariant(signature = "dict")]
 pub struct PreparePrint {
     /// The printing settings.
@@ -610,11 +610,11 @@ pub struct PreparePrint {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Print`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Print).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Print")]
-pub struct PrintProxy<'a>(zbus::Proxy<'a>);
+pub struct Print<'a>(zbus::Proxy<'a>);
 
-impl<'a> PrintProxy<'a> {
-    /// Create a new instance of [`PrintProxy`].
-    pub async fn new() -> Result<PrintProxy<'a>, Error> {
+impl<'a> Print<'a> {
+    /// Create a new instance of [`Print`].
+    pub async fn new() -> Result<Print<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Print")?
@@ -675,7 +675,7 @@ impl<'a> PrintProxy<'a> {
     /// * `title` - The title for the print dialog.
     /// * `fd` - File descriptor for reading the content to print.
     /// * `token` - A token returned by a call to
-    ///   [`prepare_print()`][`PrintProxy::prepare_print`].
+    ///   [`prepare_print()`][`Print::prepare_print`].
     /// * `modal` - Whether the dialog should be a modal.
     ///
     /// # Specifications

--- a/src/desktop/proxy_resolver.rs
+++ b/src/desktop/proxy_resolver.rs
@@ -2,10 +2,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::proxy_resolver::ProxyResolverProxy;
+//! use ashpd::desktop::proxy_resolver::ProxyResolver;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = ProxyResolverProxy::new().await?;
+//!     let proxy = ProxyResolver::new().await?;
 //!
 //!     println!("{:#?}", proxy.lookup("www.google.com").await?);
 //!
@@ -27,11 +27,11 @@ use crate::{
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.ProxyResolver`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.ProxyResolver).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.ProxyResolver")]
-pub struct ProxyResolverProxy<'a>(zbus::Proxy<'a>);
+pub struct ProxyResolver<'a>(zbus::Proxy<'a>);
 
-impl<'a> ProxyResolverProxy<'a> {
-    /// Create a new instance of [`ProxyResolverProxy`].
-    pub async fn new() -> Result<ProxyResolverProxy<'a>, Error> {
+impl<'a> ProxyResolver<'a> {
+    /// Create a new instance of [`ProxyResolver`].
+    pub async fn new() -> Result<ProxyResolver<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.ProxyResolver")?

--- a/src/desktop/realtime.rs
+++ b/src/desktop/realtime.rs
@@ -9,11 +9,11 @@ use crate::{
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Realtime`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Realtime).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Realtime")]
-pub struct RealtimeProxy<'a>(zbus::Proxy<'a>);
+pub struct Realtime<'a>(zbus::Proxy<'a>);
 
-impl<'a> RealtimeProxy<'a> {
-    /// Create a new instance of [`RealtimeProxy`].
-    pub async fn new() -> Result<RealtimeProxy<'a>, Error> {
+impl<'a> Realtime<'a> {
+    /// Create a new instance of [`Realtime`].
+    pub async fn new() -> Result<Realtime<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Realtime")?

--- a/src/desktop/request.rs
+++ b/src/desktop/request.rs
@@ -17,8 +17,8 @@ use crate::{
     Error,
 };
 
-/// A typical response returned by the [`RequestProxy::receive_response`] signal
-/// of a [`RequestProxy`].
+/// A typical response returned by the [`Request::receive_response`] signal
+/// of a [`Request`].
 #[derive(Debug)]
 pub(crate) enum Response<T>
 where
@@ -164,14 +164,14 @@ impl From<ResponseError> for ResponseType {
 /// the "Response" signal on the Request object.
 ///
 /// The application can abort the interaction calling
-/// [`close()`][`RequestProxy::close`] on the Request object.
+/// [`close()`][`Request::close`] on the Request object.
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Request`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Request).
 #[doc(alias = "org.freedesktop.portal.Request")]
-pub(crate) struct RequestProxy<'a>(zbus::Proxy<'a>);
+pub(crate) struct Request<'a>(zbus::Proxy<'a>);
 
-impl<'a> RequestProxy<'a> {
-    pub async fn new<P>(path: P) -> Result<RequestProxy<'a>, Error>
+impl<'a> Request<'a> {
+    pub async fn new<P>(path: P) -> Result<Request<'a>, Error>
     where
         P: TryInto<ObjectPath<'a>>,
         P::Error: Into<zbus::Error>,
@@ -186,7 +186,7 @@ impl<'a> RequestProxy<'a> {
         Ok(Self(proxy))
     }
 
-    pub async fn from_unique_name(handle_token: &HandleToken) -> Result<RequestProxy<'a>, Error> {
+    pub async fn from_unique_name(handle_token: &HandleToken) -> Result<Request<'a>, Error> {
         let connection = session_connection().await?;
         let unique_name = connection.unique_name().unwrap();
         let unique_identifier = unique_name.trim_start_matches(':').replace('.', "_");
@@ -233,9 +233,9 @@ impl<'a> RequestProxy<'a> {
     }
 }
 
-impl<'a> Debug for RequestProxy<'a> {
+impl<'a> Debug for Request<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RequestProxy")
+        f.debug_tuple("Request")
             .field(&self.inner().path().as_str())
             .finish()
     }

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -15,10 +15,10 @@
 //! Or by using the Proxy directly
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::ScreenshotProxy, WindowIdentifier};
+//! use ashpd::{desktop::screenshot::Screenshot, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = ScreenshotProxy::new().await?;
+//!     let proxy = Screenshot::new().await?;
 //!
 //!     let uri = proxy
 //!         .screenshot(&WindowIdentifier::default(), true, true)
@@ -44,10 +44,10 @@
 //! Or by using the Proxy directly
 //!
 //! ```rust,no_run
-//! use ashpd::{desktop::screenshot::ScreenshotProxy, WindowIdentifier};
+//! use ashpd::{desktop::screenshot::Screenshot, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = ScreenshotProxy::new().await?;
+//!     let proxy = Screenshot::new().await?;
 //!
 //!     let color = proxy.pick_color(&WindowIdentifier::default()).await?;
 //!     println!("({}, {}, {})", color.red(), color.green(), color.blue());
@@ -67,7 +67,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Clone, Debug, Default)]
-/// Specified options for a [`ScreenshotProxy::screenshot`] request.
+/// Specified options for a [`Screenshot::screenshot`] request.
 #[zvariant(signature = "dict")]
 struct ScreenshotOptions {
     /// A string that will be used as the last element of the handle.
@@ -97,21 +97,21 @@ impl ScreenshotOptions {
 }
 
 #[derive(DeserializeDict, SerializeDict, Clone, Type)]
-/// A response to a [`ScreenshotProxy::screenshot`] request.
+/// A response to a [`Screenshot::screenshot`] request.
 #[zvariant(signature = "dict")]
-struct Screenshot {
+struct ScreenshotResponse {
     /// The screenshot uri.
     uri: String,
 }
 
-impl Debug for Screenshot {
+impl Debug for ScreenshotResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.uri)
     }
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Clone, Debug, Default)]
-/// Specified options for a [`ScreenshotProxy::pick_color`] request.
+/// Specified options for a [`Screenshot::pick_color`] request.
 #[zvariant(signature = "dict")]
 struct PickColorOptions {
     /// A string that will be used as the last element of the handle.
@@ -119,7 +119,7 @@ struct PickColorOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Clone, Copy, PartialEq, Type)]
-/// A response to a [`ScreenshotProxy::pick_color`] request.
+/// A response to a [`Screenshot::pick_color`] request.
 /// **Note** the values are normalized.
 #[zvariant(signature = "dict")]
 pub struct Color {
@@ -187,11 +187,11 @@ impl std::fmt::Display for Color {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Screenshot`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Screenshot).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Screenshot")]
-pub struct ScreenshotProxy<'a>(zbus::Proxy<'a>);
+pub struct Screenshot<'a>(zbus::Proxy<'a>);
 
-impl<'a> ScreenshotProxy<'a> {
-    /// Create a new instance of [`ScreenshotProxy`].
-    pub async fn new() -> Result<ScreenshotProxy<'a>, Error> {
+impl<'a> Screenshot<'a> {
+    /// Create a new instance of [`Screenshot`].
+    pub async fn new() -> Result<Screenshot<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Screenshot")?
@@ -256,7 +256,7 @@ impl<'a> ScreenshotProxy<'a> {
         let options = ScreenshotOptions::default()
             .interactive(interactive)
             .modal(modal);
-        let response: Screenshot = call_request_method(
+        let response: ScreenshotResponse = call_request_method(
             self.inner(),
             &options.handle_token,
             "Screenshot",
@@ -268,19 +268,19 @@ impl<'a> ScreenshotProxy<'a> {
 }
 
 #[doc(alias = "xdp_portal_pick_color")]
-/// A handy wrapper around [`ScreenshotProxy::pick_color`].
+/// A handy wrapper around [`Screenshot::pick_color`].
 pub async fn pick_color(identifier: &WindowIdentifier) -> Result<Color, Error> {
-    let proxy = ScreenshotProxy::new().await?;
+    let proxy = Screenshot::new().await?;
     proxy.pick_color(identifier).await
 }
 
 #[doc(alias = "xdp_portal_take_screenshot")]
-/// A handy wrapper around [`ScreenshotProxy::screenshot`].
+/// A handy wrapper around [`Screenshot::screenshot`].
 pub async fn take(
     identifier: &WindowIdentifier,
     interactive: bool,
     modal: bool,
 ) -> Result<String, Error> {
-    let proxy = ScreenshotProxy::new().await?;
+    let proxy = Screenshot::new().await?;
     proxy.screenshot(identifier, interactive, modal).await
 }

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -3,10 +3,10 @@
 //! ```rust,no_run
 //! use std::io::Read;
 //!
-//! use ashpd::desktop::secret::SecretProxy;
+//! use ashpd::desktop::secret::Secret;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = SecretProxy::new().await?;
+//!     let proxy = Secret::new().await?;
 //!
 //!     let (mut x1, x2) = std::os::unix::net::UnixStream::pair().unwrap();
 //!     proxy.retrieve_secret(&x2).await?;
@@ -33,7 +33,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, Type, Debug, Default)]
-/// Specified options for a [`SecretProxy::retrieve_secret`] request.
+/// Specified options for a [`Secret::retrieve_secret`] request.
 #[zvariant(signature = "dict")]
 struct RetrieveOptions {
     handle_token: HandleToken,
@@ -44,7 +44,7 @@ struct RetrieveOptions {
 
 impl RetrieveOptions {
     /// Sets the token received on a previous call to
-    /// [`SecretProxy::retrieve_secret`].
+    /// [`Secret::retrieve_secret`].
     #[must_use]
     #[allow(unused)]
     pub fn token(mut self, token: &str) -> Self {
@@ -60,11 +60,11 @@ impl RetrieveOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Secret`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Secret).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Secret")]
-pub struct SecretProxy<'a>(zbus::Proxy<'a>);
+pub struct Secret<'a>(zbus::Proxy<'a>);
 
-impl<'a> SecretProxy<'a> {
-    /// Create a new instance of [`SecretProxy`].
-    pub async fn new() -> Result<SecretProxy<'a>, Error> {
+impl<'a> Secret<'a> {
+    /// Create a new instance of [`Secret`].
+    pub async fn new() -> Result<Secret<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Secret")?
@@ -99,11 +99,11 @@ impl<'a> SecretProxy<'a> {
     }
 }
 
-/// A handy wrapper around [`SecretProxy::retrieve_secret`].
+/// A handy wrapper around [`Secret::retrieve_secret`].
 ///
 /// It crates a UnixStream internally for receiving the secret.
 pub async fn retrieve_secret() -> Result<Vec<u8>, Error> {
-    let proxy = SecretProxy::new().await?;
+    let proxy = Secret::new().await?;
 
     let (mut x1, x2) = UnixStream::pair()?;
     proxy.retrieve_secret(&x2).await?;

--- a/src/desktop/session.rs
+++ b/src/desktop/session.rs
@@ -17,19 +17,19 @@ pub type SessionDetails = HashMap<String, OwnedValue>;
 /// Session object, which will stay alive for the duration of the session.
 ///
 /// The duration of the session is defined by the interface that creates it.
-/// For convenience, the interface contains a method [`SessionProxy::close`],
-/// and a signal [`SessionProxy::receive_closed`]. Whether it is allowed to
-/// directly call [`SessionProxy::close`] depends on the interface.
+/// For convenience, the interface contains a method [`Session::close`],
+/// and a signal [`Session::receive_closed`]. Whether it is allowed to
+/// directly call [`Session::close`] depends on the interface.
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Session`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Session).
 #[doc(alias = "org.freedesktop.portal.Session")]
-pub struct SessionProxy<'a>(zbus::Proxy<'a>);
+pub struct Session<'a>(zbus::Proxy<'a>);
 
-impl<'a> SessionProxy<'a> {
-    /// Create a new instance of [`SessionProxy`].
+impl<'a> Session<'a> {
+    /// Create a new instance of [`Session`].
     ///
-    /// **Note** A [`SessionProxy`] is not supposed to be created manually.
-    pub(crate) async fn new(path: ObjectPath<'a>) -> Result<SessionProxy<'a>, Error> {
+    /// **Note** A [`Session`] is not supposed to be created manually.
+    pub(crate) async fn new(path: ObjectPath<'a>) -> Result<Session<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Session")?
@@ -42,7 +42,7 @@ impl<'a> SessionProxy<'a> {
 
     pub(crate) async fn from_unique_name(
         handle_token: &HandleToken,
-    ) -> Result<SessionProxy<'a>, crate::Error> {
+    ) -> Result<Session<'a>, crate::Error> {
         let connection = session_connection().await?;
         let unique_name = connection.unique_name().unwrap();
         let unique_identifier = unique_name.trim_start_matches(':').replace('.', "_");
@@ -83,7 +83,7 @@ impl<'a> SessionProxy<'a> {
     }
 }
 
-impl<'a> Serialize for SessionProxy<'a> {
+impl<'a> Serialize for Session<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -92,15 +92,15 @@ impl<'a> Serialize for SessionProxy<'a> {
     }
 }
 
-impl<'a> Type for SessionProxy<'a> {
+impl<'a> Type for Session<'a> {
     fn signature() -> Signature<'static> {
         ObjectPath::signature()
     }
 }
 
-impl<'a> Debug for SessionProxy<'a> {
+impl<'a> Debug for Session<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SessionProxy")
+        f.debug_tuple("Session")
             .field(&self.inner().path().as_str())
             .finish()
     }

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -1,8 +1,8 @@
 //! ```rust,no_run
-//! use ashpd::desktop::settings::SettingsProxy;
+//! use ashpd::desktop::settings::Settings;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = SettingsProxy::new().await?;
+//!     let proxy = Settings::new().await?;
 //!
 //!     println!(
 //!         "{:#?}",
@@ -86,11 +86,11 @@ pub enum ColorScheme {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Settings`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Settings).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Settings")]
-pub struct SettingsProxy<'a>(zbus::Proxy<'a>);
+pub struct Settings<'a>(zbus::Proxy<'a>);
 
-impl<'a> SettingsProxy<'a> {
-    /// Create a new instance of [`SettingsProxy`].
-    pub async fn new() -> Result<SettingsProxy<'a>, Error> {
+impl<'a> Settings<'a> {
+    /// Create a new instance of [`Settings`].
+    pub async fn new() -> Result<Settings<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Settings")?

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -18,11 +18,11 @@
 //! ```rust,no_run
 //! use std::fs::File;
 //!
-//! use ashpd::desktop::trash::TrashProxy;
+//! use ashpd::desktop::trash::Trash;
 //!
 //! async fn run() -> ashpd::Result<()> {
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
-//!     let proxy = TrashProxy::new().await?;
+//!     let proxy = Trash::new().await?;
 //!     proxy.trash_file(&file).await?;
 //!     Ok(())
 //! }
@@ -55,11 +55,11 @@ enum TrashStatus {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Trash`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Trash).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Trash")]
-pub struct TrashProxy<'a>(zbus::Proxy<'a>);
+pub struct Trash<'a>(zbus::Proxy<'a>);
 
-impl<'a> TrashProxy<'a> {
-    /// Create a new instance of [`TrashProxy`].
-    pub async fn new() -> Result<TrashProxy<'a>, Error> {
+impl<'a> Trash<'a> {
+    /// Create a new instance of [`Trash`].
+    pub async fn new() -> Result<Trash<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Trash")?
@@ -98,9 +98,9 @@ impl<'a> TrashProxy<'a> {
 }
 
 #[doc(alias = "xdp_portal_trash_file")]
-/// A handy wrapper around [`TrashProxy::trash_file`].
+/// A handy wrapper around [`Trash::trash_file`].
 pub async fn trash_file(fd: &impl AsRawFd) -> Result<(), Error> {
-    let proxy = TrashProxy::new().await?;
+    let proxy = Trash::new().await?;
     proxy.trash_file(fd).await
 }
 

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -23,14 +23,14 @@
 //! use std::fs::File;
 //!
 //! use ashpd::{
-//!     desktop::wallpaper::{SetOn, WallpaperProxy},
+//!     desktop::wallpaper::{SetOn, Wallpaper},
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
 //!     let wallpaper = File::open("/home/bilelmoussaoui/adwaita-day.jpg").unwrap();
 //!
-//!     let proxy = WallpaperProxy::new().await?;
+//!     let proxy = Wallpaper::new().await?;
 //!     proxy
 //!         .set_wallpaper_file(&WindowIdentifier::default(), &wallpaper, true, SetOn::Both)
 //!         .await?;
@@ -57,12 +57,12 @@
 //!
 //! ```rust,no_run
 //! use ashpd::{
-//!     desktop::wallpaper::{SetOn, WallpaperProxy},
+//!     desktop::wallpaper::{SetOn, Wallpaper},
 //!     WindowIdentifier,
 //! };
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = WallpaperProxy::new().await?;
+//!     let proxy = Wallpaper::new().await?;
 //!     proxy
 //!         .set_wallpaper_uri(
 //!             &WindowIdentifier::default(),
@@ -142,8 +142,8 @@ impl FromStr for SetOn {
 }
 
 #[derive(SerializeDict, DeserializeDict, Clone, Type, Debug, Default)]
-/// Specified options for a [`WallpaperProxy::set_wallpaper_file`] or a
-/// [`WallpaperProxy::set_wallpaper_uri`] request.
+/// Specified options for a [`Wallpaper::set_wallpaper_file`] or a
+/// [`Wallpaper::set_wallpaper_uri`] request.
 #[zvariant(signature = "dict")]
 struct WallpaperOptions {
     /// A string that will be used as the last element of the handle.
@@ -179,11 +179,11 @@ impl WallpaperOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Wallpaper`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Wallpaper).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Wallpaper")]
-pub struct WallpaperProxy<'a>(zbus::Proxy<'a>);
+pub struct Wallpaper<'a>(zbus::Proxy<'a>);
 
-impl<'a> WallpaperProxy<'a> {
-    /// Create a new instance of [`WallpaperProxy`].
-    pub async fn new() -> Result<WallpaperProxy<'a>, Error> {
+impl<'a> Wallpaper<'a> {
+    /// Create a new instance of [`Wallpaper`].
+    pub async fn new() -> Result<Wallpaper<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Wallpaper")?
@@ -268,14 +268,14 @@ impl<'a> WallpaperProxy<'a> {
 }
 
 #[doc(alias = "xdp_portal_set_wallpaper")]
-/// A handy wrapper around [`WallpaperProxy::set_wallpaper_uri`].
+/// A handy wrapper around [`Wallpaper::set_wallpaper_uri`].
 pub async fn set_from_uri(
     identifier: &WindowIdentifier,
     uri: &str,
     show_preview: bool,
     set_on: SetOn,
 ) -> Result<(), Error> {
-    let proxy = WallpaperProxy::new().await?;
+    let proxy = Wallpaper::new().await?;
     proxy
         .set_wallpaper_uri(identifier, uri, show_preview, set_on)
         .await?;
@@ -283,14 +283,14 @@ pub async fn set_from_uri(
 }
 
 #[doc(alias = "xdp_portal_set_wallpaper")]
-/// A handy wrapper around [`WallpaperProxy::set_wallpaper_file`].
+/// A handy wrapper around [`Wallpaper::set_wallpaper_file`].
 pub async fn set_from_file(
     identifier: &WindowIdentifier,
     file: &impl AsRawFd,
     show_preview: bool,
     set_on: SetOn,
 ) -> Result<(), Error> {
-    let proxy = WallpaperProxy::new().await?;
+    let proxy = Wallpaper::new().await?;
     proxy
         .set_wallpaper_file(identifier, file, show_preview, set_on)
         .await?;

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -3,10 +3,10 @@
 //! ```rust,no_run
 //! use std::fs::File;
 //!
-//! use ashpd::documents::FileTransferProxy;
+//! use ashpd::documents::FileTransfer;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FileTransferProxy::new().await?;
+//!     let proxy = FileTransfer::new().await?;
 //!
 //!     let key = proxy.start_transfer(true, true).await?;
 //!     let file = File::open("/home/bilelmoussaoui/Downloads/adwaita-night.jpg").unwrap();
@@ -33,13 +33,13 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Debug, Type, Default)]
-/// Specified options for a [`FileTransferProxy::start_transfer`] request.
+/// Specified options for a [`FileTransfer::start_transfer`] request.
 #[zvariant(signature = "dict")]
 struct TransferOptions {
     /// Whether to allow the chosen application to write to the files.
     writeable: Option<bool>,
     /// Whether to stop the transfer automatically after the first
-    /// [`retrieve_files()`][`FileTransferProxy::retrieve_files`] call.
+    /// [`retrieve_files()`][`FileTransfer::retrieve_files`] call.
     #[zvariant(rename = "autostop")]
     auto_stop: Option<bool>,
 }
@@ -53,7 +53,7 @@ impl TransferOptions {
     }
 
     /// Whether to stop the transfer automatically after the first
-    /// [`retrieve_files()`][`FileTransferProxy::retrieve_files`] call.
+    /// [`retrieve_files()`][`FileTransfer::retrieve_files`] call.
     #[must_use]
     pub fn auto_stop(mut self, auto_stop: bool) -> Self {
         self.auto_stop = Some(auto_stop);
@@ -78,11 +78,11 @@ impl TransferOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.FileTransfer`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.FileTransfer).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.FileTransfer")]
-pub struct FileTransferProxy<'a>(zbus::Proxy<'a>);
+pub struct FileTransfer<'a>(zbus::Proxy<'a>);
 
-impl<'a> FileTransferProxy<'a> {
-    /// Create a new instance of [`FileTransferProxy`].
-    pub async fn new() -> Result<FileTransferProxy<'a>, Error> {
+impl<'a> FileTransfer<'a> {
+    /// Create a new instance of [`FileTransfer`].
+    pub async fn new() -> Result<FileTransfer<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.FileTransfer")?
@@ -105,7 +105,7 @@ impl<'a> FileTransferProxy<'a> {
     /// # Arguments
     ///
     /// * `key` - A key returned by
-    ///   [`start_transfer()`][`FileTransferProxy::start_transfer`].
+    ///   [`start_transfer()`][`FileTransfer::start_transfer`].
     /// * `fds` - A list of file descriptors of the files to register.
     ///
     /// # Specifications
@@ -121,14 +121,14 @@ impl<'a> FileTransferProxy<'a> {
     }
 
     /// Retrieves files that were previously added to the session with
-    /// [`add_files()`][`FileTransferProxy::add_files`]. The files will be
+    /// [`add_files()`][`FileTransfer::add_files`]. The files will be
     /// exported in the document portal as-needed for the caller, and they
     /// will be writable if the owner of the session allowed it.
     ///
     /// # Arguments
     ///
     /// * `key` - A key returned by
-    ///   [`start_transfer()`][`FileTransferProxy::start_transfer`].
+    ///   [`start_transfer()`][`FileTransfer::start_transfer`].
     ///
     /// # Returns
     ///
@@ -147,7 +147,7 @@ impl<'a> FileTransferProxy<'a> {
     }
 
     /// Starts a session for a file transfer.
-    /// The caller should call [`add_files()`][`FileTransferProxy::add_files`]
+    /// The caller should call [`add_files()`][`FileTransfer::add_files`]
     /// at least once, to add files to this session.
     ///
     /// # Arguments
@@ -155,12 +155,12 @@ impl<'a> FileTransferProxy<'a> {
     /// * `writeable` - Sets whether the chosen application can write to the
     ///   files or not.
     /// * `auto_stop` - Whether to stop the transfer automatically after the
-    ///   first [`retrieve_files()`][`FileTransferProxy::retrieve_files`] call.
+    ///   first [`retrieve_files()`][`FileTransfer::retrieve_files`] call.
     ///
     /// # Returns
     ///
     /// Key that can be passed to
-    /// [`retrieve_files()`][`FileTransferProxy::retrieve_files`] to obtain the
+    /// [`retrieve_files()`][`FileTransfer::retrieve_files`] to obtain the
     /// files.
     ///
     /// # Specifications
@@ -174,14 +174,14 @@ impl<'a> FileTransferProxy<'a> {
     }
 
     /// Ends the transfer.
-    /// Further calls to [`add_files()`][`FileTransferProxy::add_files`] or
-    /// [`retrieve_files()`][`FileTransferProxy::retrieve_files`] for this key
+    /// Further calls to [`add_files()`][`FileTransfer::add_files`] or
+    /// [`retrieve_files()`][`FileTransfer::retrieve_files`] for this key
     /// will return an error.
     ///
     /// # Arguments
     ///
     /// * `key` - A key returned by
-    ///   [`start_transfer()`][`FileTransferProxy::start_transfer`].
+    ///   [`start_transfer()`][`FileTransfer::start_transfer`].
     ///
     /// # Specifications
     ///
@@ -196,7 +196,7 @@ impl<'a> FileTransferProxy<'a> {
     /// # Returns
     ///
     /// * The key returned by
-    ///   [`start_transfer()`][`FileTransferProxy::start_transfer`].
+    ///   [`start_transfer()`][`FileTransfer::start_transfer`].
     ///
     /// # Specifications
     ///

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -1,10 +1,10 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ashpd::documents::{DocumentsProxy, Permission};
+//! use ashpd::documents::{Documents, Permission};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = DocumentsProxy::new().await?;
+//!     let proxy = Documents::new().await?;
 //!
 //!     println!("{:#?}", proxy.mount_point().await?);
 //!
@@ -151,21 +151,21 @@ impl FromStr for Permission {
 ///
 /// Individual files will appear at `/run/user/$UID/doc/$DOC_ID/filename`,
 /// where `$DOC_ID` is the ID of the file in the document store.
-/// It is returned by the [`DocumentsProxy::add`] and
-/// [`DocumentsProxy::add_named`] calls.
+/// It is returned by the [`Documents::add`] and
+/// [`Documents::add_named`] calls.
 ///
 /// The permissions that the application has for a document store entry (see
-/// [`DocumentsProxy::grant_permissions`]) are reflected in the POSIX mode bits
+/// [`Documents::grant_permissions`]) are reflected in the POSIX mode bits
 /// in the fuse filesystem.
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Documents`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Documents).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Documents")]
-pub struct DocumentsProxy<'a>(zbus::Proxy<'a>);
+pub struct Documents<'a>(zbus::Proxy<'a>);
 
-impl<'a> DocumentsProxy<'a> {
-    /// Create a new instance of [`DocumentsProxy`].
-    pub async fn new() -> Result<DocumentsProxy<'a>, Error> {
+impl<'a> Documents<'a> {
+    /// Create a new instance of [`Documents`].
+    pub async fn new() -> Result<Documents<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Documents")?
@@ -520,7 +520,7 @@ impl<'a> DocumentsProxy<'a> {
 /// Interact with `org.freedesktop.portal.FileTransfer` interface.
 mod file_transfer;
 
-pub use file_transfer::FileTransferProxy;
+pub use file_transfer::FileTransfer;
 
 #[cfg(test)]
 mod tests {

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -5,11 +5,11 @@
 //! ```rust,no_run
 //! use std::collections::HashMap;
 //!
-//! use ashpd::flatpak::{FlatpakProxy, SpawnFlags, SpawnOptions};
+//! use ashpd::flatpak::{Flatpak, SpawnFlags, SpawnOptions};
 //! use enumflags2::BitFlags;
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FlatpakProxy::new().await?;
+//!     let proxy = Flatpak::new().await?;
 //!
 //!     proxy
 //!         .spawn(
@@ -112,7 +112,7 @@ pub enum SupportsFlags {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`FlatpakProxy::spawn`] request.
+/// Specified options for a [`Flatpak::spawn`] request.
 #[zvariant(signature = "dict")]
 pub struct SpawnOptions {
     /// A list of filenames for files inside the sandbox that will be exposed to
@@ -235,7 +235,7 @@ impl SpawnOptions {
 }
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`FlatpakProxy::create_update_monitor`] request.
+/// Specified options for a [`Flatpak::create_update_monitor`] request.
 ///
 /// Currently there are no possible options yet.
 #[zvariant(signature = "dict")]
@@ -248,11 +248,11 @@ struct CreateMonitorOptions {}
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Flatpak`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Flatpak).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Flatpak")]
-pub struct FlatpakProxy<'a>(zbus::Proxy<'a>);
+pub struct Flatpak<'a>(zbus::Proxy<'a>);
 
-impl<'a> FlatpakProxy<'a> {
-    /// Create a new instance of [`FlatpakProxy`].
-    pub async fn new() -> Result<FlatpakProxy<'a>, Error> {
+impl<'a> Flatpak<'a> {
+    /// Create a new instance of [`Flatpak`].
+    pub async fn new() -> Result<Flatpak<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Flatpak")?
@@ -277,21 +277,21 @@ impl<'a> FlatpakProxy<'a> {
     /// See also [`CreateUpdateMonitor`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-method-org-freedesktop-portal-Flatpak.CreateUpdateMonitor).
     #[doc(alias = "CreateUpdateMonitor")]
     #[doc(alias = "xdp_portal_update_monitor_start")]
-    pub async fn create_update_monitor(&self) -> Result<UpdateMonitorProxy<'a>, Error> {
+    pub async fn create_update_monitor(&self) -> Result<UpdateMonitor<'a>, Error> {
         let options = CreateMonitorOptions::default();
         let path: OwnedObjectPath =
             call_method(self.inner(), "CreateUpdateMonitor", &(options)).await?;
 
-        UpdateMonitorProxy::new(path.into_inner()).await
+        UpdateMonitor::new(path.into_inner()).await
     }
 
-    /// Emitted when a process starts by [`spawn()`][`FlatpakProxy::spawn`].
+    /// Emitted when a process starts by [`spawn()`][`Flatpak::spawn`].
     #[doc(alias = "SpawnStarted")]
     pub async fn receive_spawn_started(&self) -> Result<(u32, u32), Error> {
         receive_signal(self.inner(), "SpawnStarted").await
     }
 
-    /// Emitted when a process started by [`spawn()`][`FlatpakProxy::spawn`]
+    /// Emitted when a process started by [`spawn()`][`Flatpak::spawn`]
     /// exits.
     ///
     /// # Specifications
@@ -362,7 +362,7 @@ impl<'a> FlatpakProxy<'a> {
     }
 
     /// This methods let you send a Unix signal to a process that was started
-    /// [`spawn()`][`FlatpakProxy::spawn`].
+    /// [`spawn()`][`Flatpak::spawn`].
     ///
     /// # Arguments
     ///
@@ -404,4 +404,4 @@ impl<'a> FlatpakProxy<'a> {
 
 /// Monitor if there's an update it and install it.
 mod update_monitor;
-pub use update_monitor::{UpdateInfo, UpdateMonitorProxy, UpdateProgress, UpdateStatus};
+pub use update_monitor::{UpdateInfo, UpdateMonitor, UpdateProgress, UpdateStatus};

--- a/src/flatpak/update_monitor.rs
+++ b/src/flatpak/update_monitor.rs
@@ -4,10 +4,10 @@
 //! Only available for Flatpak applications.
 //!
 //! ```rust,no_run
-//! use ashpd::{flatpak::FlatpakProxy, WindowIdentifier};
+//! use ashpd::{flatpak::Flatpak, WindowIdentifier};
 //!
 //! async fn run() -> ashpd::Result<()> {
-//!     let proxy = FlatpakProxy::new().await?;
+//!     let proxy = Flatpak::new().await?;
 //!
 //!     let monitor = proxy.create_update_monitor().await?;
 //!     let info = monitor.receive_update_available().await?;
@@ -30,7 +30,7 @@ use crate::{
 };
 
 #[derive(SerializeDict, DeserializeDict, Type, Debug, Default)]
-/// Specified options for a [`UpdateMonitorProxy::update`] request.
+/// Specified options for a [`UpdateMonitor::update`] request.
 ///
 /// Currently there are no possible options yet.
 #[zvariant(signature = "dict")]
@@ -109,14 +109,14 @@ pub struct UpdateProgress {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Flatpak.UpdateMonitor`](https://flatpak.github.io/xdg-desktop-portal/index.html#gdbus-org.freedesktop.portal.Flatpak.UpdateMonitor).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Flatpak.UpdateMonitor")]
-pub struct UpdateMonitorProxy<'a>(zbus::Proxy<'a>);
+pub struct UpdateMonitor<'a>(zbus::Proxy<'a>);
 
-impl<'a> UpdateMonitorProxy<'a> {
-    /// Create a new instance of [`UpdateMonitorProxy`].
+impl<'a> UpdateMonitor<'a> {
+    /// Create a new instance of [`UpdateMonitor`].
     ///
-    /// **Note** A [`UpdateMonitorProxy`] is not supposed to be created
+    /// **Note** A [`UpdateMonitor`] is not supposed to be created
     /// manually.
-    pub(crate) async fn new(path: ObjectPath<'a>) -> Result<UpdateMonitorProxy<'a>, Error> {
+    pub(crate) async fn new(path: ObjectPath<'a>) -> Result<UpdateMonitor<'a>, Error> {
         let connection = session_connection().await?;
         let proxy = zbus::ProxyBuilder::new_bare(&connection)
             .interface("org.freedesktop.portal.Flatpak.UpdateMonitor")?

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -15,7 +15,7 @@ use zbus::zvariant::{ObjectPath, OwnedObjectPath, Type};
 
 use crate::{
     desktop::{
-        request::{BasicResponse, RequestProxy, Response},
+        request::{BasicResponse, Request, Response},
         HandleToken,
     },
     Error, PortalError, SESSION,
@@ -39,7 +39,7 @@ where
     );
     #[cfg(feature = "tracing")]
     tracing::debug!("The body is: {:#?}", body);
-    let request = RequestProxy::from_unique_name(handle_token).await?;
+    let request = Request::from_unique_name(handle_token).await?;
     // We don't use receive_response because we want to create the stream in advance
     #[cfg(feature = "tracing")]
     tracing::info!(


### PR DESCRIPTION
This also renames some types to simplify things.
Currently only EmailProxy have not been renamed but
the plan for this one is to convert it to a builder pattern like type
and keep the Proxy as an internal implementation API