### PR TITLE
Pin exact wayland-client versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ futures = "0.3"
 tracing = {version = "0.1", optional = true}
 libc = {version = "0.2.94", optional = true}
 raw-window-handle = {version = "0.4", optional = true}
-wayland-client = {version = "0.30.0-beta.3", optional = true}
-wayland-protocols = {version = "0.30.0-beta.3", optional = true, features = ["unstable", "client"]}
-wayland-backend = {version = "0.1.0-beta.3", optional = true, features = ["client_system"]}
+wayland-client = {version = "=0.30.0-beta.3", optional = true}
+wayland-protocols = {version = "=0.30.0-beta.3", optional = true, features = ["unstable", "client"]}
+wayland-scanner = {version = "=0.30.0-beta.3", optional = true}
+wayland-backend = {version = "=0.1.0-beta.3", optional = true, features = ["client_system"]}
 async-std = {version = "1.11", optional = true}
 tokio = {version = "1.17", features = ["fs", "io-util"], optional = true, default-features = false}
 once_cell = "1.9"


### PR DESCRIPTION
I recently tried to use the wayland feature, but it failed because it was pulling in incompatible versions of the various wayland packages. I think the underlying issue is that "0.3.0-beta.3" is not semver compatible with "0.3.0-beta.8", but [cargo thinks it is](git@github.com:bilelmoussaoui/ashpd.git). The fix is to pin the exact versions, and I also had to add an explicit dependency on `wayland-scanner` because otherwise it pulls in `wayland-scanner-0.3.0-beta.8`.