### PR TITLE
Fix incorrect KeyState mapping in RemoteDesktopProxy

### DIFF
--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -95,10 +95,10 @@ use crate::{
 pub enum KeyState {
     #[doc(alias = "XDP_KEY_PRESSED")]
     /// The key is pressed.
-    Pressed = 0,
+    Pressed = 1,
     #[doc(alias = "XDP_KEY_RELEASED")]
     /// The key is released..
-    Released = 1,
+    Released = 0,
 }
 
 #[bitflags]


### PR DESCRIPTION
The KeyState enum for the RemoteDesktopProxy incorrectly maps "Pressed" to 0 and "Released" to 1 when it should be the other way around. (see [here](https://flatpak.github.io/xdg-desktop-portal/#gdbus-method-org-freedesktop-portal-RemoteDesktop.NotifyKeyboardKeycode))
This PR fixes that.