### PR TITLE
Bump pipewire crate to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ gdk4wayland = {package = "gdk4-wayland", version = "0.6", optional = true}
 gdk4x11 = {package = "gdk4-x11", version = "0.6", optional = true}
 gtk4 = {version = "0.6", optional = true}
 
-pw = {package= "pipewire", version = "0.5", optional = true}
+pw = {package= "pipewire", version = "0.6", optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_repr = "0.1"
 rand = {version = "0.8", default-features = false}


### PR DESCRIPTION
Fixes the compilation errors with pipewire 0.3.64 / 0.3.65 (#118).