### PR TITLE
Duplicate all fds we have as input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 name = "ashpd"
 repository = "https://github.com/bilelmoussaoui/ashpd"
 version = "0.4.0"
+rust-version = "1.63"
 
 [features]
 async-std = ["zbus/async-io", "dep:async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ gtk3_x11 = ["gdk3x11", "dep:gtk3"]
 gtk4 = ["gtk4_x11", "gtk4_wayland"]
 gtk4_wayland = ["gdk4wayland", "dep:gtk4"]
 gtk4_x11 = ["gdk4x11", "dep:gtk4"]
-pipewire = ["pw", "libc"]
+pipewire = ["pw"]
 raw_handle = ["raw-window-handle", "wayland"]
 tokio = ["zbus/tokio", "dep:tokio"]
 wayland = ["wayland-client", "wayland-protocols", "wayland-backend"]
@@ -36,7 +36,6 @@ gdk4wayland = {package = "gdk4-wayland", version = "0.6", optional = true}
 gdk4x11 = {package = "gdk4-x11", version = "0.6", optional = true}
 gtk3 = {package = "gtk", version = "0.17", optional = true}
 gtk4 = {version = "0.6", optional = true}
-libc = {version = "0.2", optional = true}
 once_cell = "1.14"
 pw = {package = "pipewire", version = "0.6", optional = true}
 rand = {version = "0.8", default-features = false}

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -20,7 +20,7 @@ use std::{fmt::Debug, os::unix::io::AsRawFd};
 use serde_repr::Deserialize_repr;
 use zbus::zvariant::{Fd, Type};
 
-use crate::{error::PortalError, proxy::Proxy, Error};
+use crate::{error::PortalError, helpers, proxy::Proxy, Error};
 
 #[derive(Deserialize_repr, PartialEq, Eq, Debug, Type)]
 /// The status of the game mode.
@@ -114,13 +114,12 @@ impl<'a> GameMode<'a> {
         target: &impl AsRawFd,
         requester: &impl AsRawFd,
     ) -> Result<Status, Error> {
+        let target = helpers::dup_to_owned_fd(target)?;
+        let requester = helpers::dup_to_owned_fd(requester)?;
         self.0
             .call(
                 "QueryStatusByPIDFd",
-                &(
-                    Fd::from(target.as_raw_fd()),
-                    Fd::from(requester.as_raw_fd()),
-                ),
+                &(Fd::from(&target), Fd::from(&requester)),
             )
             .await
     }
@@ -179,14 +178,13 @@ impl<'a> GameMode<'a> {
         target: &impl AsRawFd,
         requester: &impl AsRawFd,
     ) -> Result<(), Error> {
+        let target = helpers::dup_to_owned_fd(target)?;
+        let requester = helpers::dup_to_owned_fd(requester)?;
         let status = self
             .0
             .call(
                 "RegisterGameByPIDFd",
-                &(
-                    Fd::from(target.as_raw_fd()),
-                    Fd::from(requester.as_raw_fd()),
-                ),
+                &(Fd::from(&target), Fd::from(&requester)),
             )
             .await?;
         match status {
@@ -256,14 +254,13 @@ impl<'a> GameMode<'a> {
         target: &impl AsRawFd,
         requester: &impl AsRawFd,
     ) -> Result<(), Error> {
+        let target = helpers::dup_to_owned_fd(target)?;
+        let requester = helpers::dup_to_owned_fd(requester)?;
         let status = self
             .0
             .call(
                 "UnregisterGameByPIDFd",
-                &(
-                    Fd::from(target.as_raw_fd()),
-                    Fd::from(requester.as_raw_fd()),
-                ),
+                &(Fd::from(&target), Fd::from(&requester)),
             )
             .await?;
         match status {

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 use zbus::zvariant::{DeserializeDict, Fd, SerializeDict, Type};
 
 use super::{HandleToken, Request};
-use crate::{proxy::Proxy, Error, WindowIdentifier};
+use crate::{helpers, proxy::Proxy, Error, WindowIdentifier};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Type)]
 #[zvariant(signature = "s")]
@@ -684,11 +684,12 @@ impl<'a> PrintProxy<'a> {
         let options = PrintOptions::default()
             .token(token.unwrap_or(0))
             .modal(modal);
+        let fd = helpers::dup_to_owned_fd(fd)?;
         self.0
             .empty_request(
                 &options.handle_token,
                 "Print",
-                &(&identifier, title, Fd::from(fd.as_raw_fd()), &options),
+                &(&identifier, title, Fd::from(&fd), &options),
             )
             .await
     }

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -45,7 +45,7 @@ use serde::{self, Deserialize, Serialize};
 use zbus::zvariant::{Fd, SerializeDict, Type};
 
 use super::Request;
-use crate::{desktop::HandleToken, proxy::Proxy, Error, WindowIdentifier};
+use crate::{desktop::HandleToken, helpers, proxy::Proxy, Error, WindowIdentifier};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Type)]
 #[zvariant(signature = "s")]
@@ -127,11 +127,12 @@ impl<'a> WallpaperProxy<'a> {
         file: &impl AsRawFd,
         options: WallpaperOptions,
     ) -> Result<Request<()>, Error> {
+        let fd = helpers::dup_to_owned_fd(file)?;
         self.0
             .empty_request(
                 &options.handle_token,
                 "SetWallpaperFile",
-                &(&identifier, Fd::from(file.as_raw_fd()), &options),
+                &(&identifier, Fd::from(&fd), &options),
             )
             .await
     }


### PR DESCRIPTION
This way we don't run into the case where the fd is closed on the app side before we are done with it. By using OwnedFd, we make sure the dupped fd is closed when it goes out of scope, after the async operation is done.

Note that the only api missing is the attach in email.rs.