### PR TITLE
Allow running the demo from the build dir

### DIFF
--- a/ashpd-demo/src/config.rs.in
+++ b/ashpd-demo/src/config.rs.in
@@ -5,3 +5,4 @@ pub const PKGDATADIR: &str = @PKGDATADIR@;
 pub const PROFILE: &str = @PROFILE@;
 pub const RESOURCES_FILE: &str = concat!(@PKGDATADIR@, "/resources.gresource");
 pub const VERSION: &str = @VERSION@;
+pub const BUILDDIR_RESOURCES_FILE: &str = concat!(@BUILDDATADIR@, "/resources.gresource");

--- a/ashpd-demo/src/main.rs
+++ b/ashpd-demo/src/main.rs
@@ -6,7 +6,7 @@ mod widgets;
 mod window;
 
 use application::Application;
-use config::{GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_FILE};
+use config::{GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_FILE, BUILDDIR_RESOURCES_FILE};
 use gettextrs::*;
 use gtk::{gio, glib};
 
@@ -24,7 +24,12 @@ fn main() -> glib::ExitCode {
 
     gst4gtk::plugin_register_static().expect("Failed to register gstgtk4 plugin");
 
-    let res = gio::Resource::load(RESOURCES_FILE).expect("Could not load gresource file");
+    let argv0 = std::env::args().next();
+    let res = if argv0.is_some() && argv0.unwrap().ends_with(".devel") {
+        gio::Resource::load(BUILDDIR_RESOURCES_FILE)
+    } else {
+        gio::Resource::load(RESOURCES_FILE)
+    }.expect("Could not load gresource file");
     gio::resources_register(&res);
 
     let mut args = std::env::args();

--- a/ashpd-demo/src/meson.build
+++ b/ashpd-demo/src/meson.build
@@ -5,6 +5,7 @@ global_conf.set_quoted('PROFILE', profile)
 global_conf.set_quoted('VERSION', version + version_suffix)
 global_conf.set_quoted('GETTEXT_PACKAGE', gettext_package)
 global_conf.set_quoted('LOCALEDIR', localedir)
+global_conf.set_quoted('BUILDDATADIR', meson.project_build_root() / 'data')
 config = configure_file(
   input: 'config.rs.in',
   output: 'config.rs',
@@ -48,5 +49,7 @@ cargo_build = custom_target(
     cargo_options,
     '&&',
     'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@',
+    '&&',
+    'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@.devel',
   ]
 )


### PR DESCRIPTION
This sits on top of #150 so it builds on my machine but can be split out if need be.

Unless there's a trick I'm missing, we can't easily run the demo from the meson build dir because it looks in `/usr/local/share/` for the gresources file. This could (possibly?) be worked around by setting the datadir in meson but another hack is to build the same binary with a `.devel` suffix, check for that suffix in `argv0` and load the gresources from the builddir instead. Not overly pretty but for this use-case it's probably good enough.