### PR TITLE
Fix docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,6 @@ byteorder = "1.4"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]
-features = ["gtk4", "raw_handle", "pipwire", "wayland"]
+features = ["gtk4", "raw_handle", "pipewire", "wayland"]
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]


### PR DESCRIPTION
A typo in `Cargo.toml` seems to be the cause of docs.rs [build failure](https://docs.rs/crate/ashpd/latest).