### PR TITLE
Correct a comment and a typo

### DIFF
--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -1,6 +1,6 @@
 //! # Examples
 //!
-//! Spawn a process outside of the sandbox, only works in a Flatpak.
+//! Spawn a process inside of the sandbox, only works in a Flatpak.
 //!
 //! ```rust,no_run
 //! use std::collections::HashMap;

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -290,7 +290,7 @@ impl<'a> Flatpak<'a> {
     /// See also [`SpawnExited`](https://flatpak.github.io/xdg-desktop-portal/docs/index.html#gdbus-signal-org-freedesktop-portal-Flatpak.SpawnExited).
     #[doc(alias = "SpawnExited")]
     #[doc(alias = "XdpPortal::spawn-exited")]
-    pub async fn receive_spawn_existed(&self) -> Result<impl Stream<Item = (u32, u32)>, Error> {
+    pub async fn receive_spawn_exited(&self) -> Result<impl Stream<Item = (u32, u32)>, Error> {
         self.0.signal("SpawnExited").await
     }
 


### PR DESCRIPTION
The first change is that `Spawn` is not about running things outside the sandbox but inside. There is a different interface for running processes outside of the sandbox.

The second one is an all-to-common typo of writing `existed` instead of `exited`. This does break API but it also fixes it so I don't know what you'd want to do about accepting that. Maybe the typoed version should be deprecated instead?