### PR TITLE
Drop async-std crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.7.0"
 rust-version = "1.65"
 
 [features]
-async-std = ["zbus/async-io", "dep:async-std"]
+async-std = ["zbus/async-io", "dep:async-fs", "dep:async-net"]
 default = ["async-std"]
 gtk4 = ["gtk4_x11", "gtk4_wayland"]
 gtk4_wayland = ["gdk4wayland", "dep:gtk4"]
@@ -23,7 +23,8 @@ tokio = ["zbus/tokio", "dep:tokio"]
 wayland = ["wayland-client", "wayland-protocols", "wayland-backend"]
 
 [dependencies]
-async-std = { version = "1.12", optional = true }
+async-fs = { version = "2.1.0", optional = true }
+async-net = { version = "2.0.0", optional = true }
 enumflags2 = "0.7"
 futures-channel = "0.3"
 futures-util = "0.3"

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -21,7 +21,9 @@
 use std::os::unix::prelude::AsRawFd;
 
 #[cfg(feature = "async-std")]
-use async_std::{os::unix::net::UnixStream, prelude::*};
+use async_net::unix::UnixStream;
+#[cfg(feature = "async-std")]
+use futures_util::AsyncReadExt;
 #[cfg(feature = "tokio")]
 use tokio::{io::AsyncReadExt, net::UnixStream};
 use zbus::zvariant::{Fd, SerializeDict, Type};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,14 +1,14 @@
 #[cfg(feature = "async-std")]
-use async_std::{fs::File, prelude::*};
+use async_fs::File;
+#[cfg(feature = "async-std")]
+use futures_util::AsyncReadExt;
 #[cfg(feature = "tokio")]
 use tokio::{fs::File, io::AsyncReadExt};
 
 pub(crate) async fn is_flatpak() -> bool {
     #[cfg(feature = "async-std")]
     {
-        async_std::path::PathBuf::from("/.flatpak-info")
-            .exists()
-            .await
+        async_fs::metadata("/.flatpak-info").await.is_ok()
     }
     #[cfg(not(feature = "async-std"))]
     {


### PR DESCRIPTION
The async-std crate didn't had a release for 1 1/2 years. It also pulls in a lot of dependencies that are usually not needed. The Path::exists() feature of async-std is just using spawn_blocking around the std metadata function and therefore settling on a specific executor and spawning a bunch of threads that might not be needed.

Therefore I replaced all uses of async-std with the crates from which async-std is build and that are well maintained.