### PR TITLE
Fix possible OnceCell panic in Proxy::connection()

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -38,8 +38,8 @@ impl<'a> Proxy<'a> {
             Ok(cnx.clone())
         } else {
             let cnx = zbus::Connection::session().await?;
-            SESSION.set(cnx.clone()).expect("Can't reset a OnceCell");
-            Ok(cnx)
+            // during `await` another task may have initialized the cell
+            Ok(SESSION.get_or_init(|| { cnx }).clone())
         }
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -39,7 +39,7 @@ impl<'a> Proxy<'a> {
         } else {
             let cnx = zbus::Connection::session().await?;
             // during `await` another task may have initialized the cell
-            Ok(SESSION.get_or_init(|| { cnx }).clone())
+            Ok(SESSION.get_or_init(|| cnx).clone())
         }
     }
 


### PR DESCRIPTION
When multiple tasks are trying to create proxies simultaneously, another task may initialize the zbus-Connection-OnceCell while the connection is initialized.

This ensures that only the first task to establish a connection initializes the OnceCell

Fixes #185