### PR TITLE
desktop/settings: fix contrast docs

### DIFF
--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -100,7 +100,7 @@ impl TryFrom<Value<'_>> for ColorScheme {
     }
 }
 
-/// The system's preferred color scheme
+/// The system's preferred contrast level
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Contrast {
     /// No preference


### PR DESCRIPTION
Fixes an issue, where [contrast settings](https://docs.rs/ashpd/0.7.0/ashpd/desktop/settings/enum.Contrast.html) have the wrong documentation.