### PR TITLE
Take impl AsFd instead of BorrowedFd

### DIFF
--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -15,7 +15,7 @@
 //! }
 //! ```
 
-use std::{fmt::Debug, os::fd::BorrowedFd};
+use std::{fmt::Debug, os::fd::AsFd};
 
 use serde_repr::Deserialize_repr;
 use zbus::zvariant::{Fd, Type};
@@ -113,8 +113,8 @@ impl<'a> GameMode<'a> {
     #[doc(alias = "QueryStatusByPIDFd")]
     pub async fn query_status_by_pidfd(
         &self,
-        target: &BorrowedFd<'_>,
-        requester: &BorrowedFd<'_>,
+        target: &impl AsFd,
+        requester: &impl AsFd,
     ) -> Result<Status, Error> {
         self.0
             .call(
@@ -179,8 +179,8 @@ impl<'a> GameMode<'a> {
     #[doc(alias = "RegisterGameByPIDFd")]
     pub async fn register_by_pidfd(
         &self,
-        target: &BorrowedFd<'_>,
-        requester: &BorrowedFd<'_>,
+        target: &impl AsFd,
+        requester: &impl AsFd,
     ) -> Result<(), Error> {
         let status = self
             .0
@@ -259,8 +259,8 @@ impl<'a> GameMode<'a> {
     #[doc(alias = "UnregisterGameByPIDFd")]
     pub async fn unregister_by_pidfd(
         &self,
-        target: &BorrowedFd<'_>,
-        requester: &BorrowedFd<'_>,
+        target: &impl AsFd,
+        requester: &impl AsFd,
     ) -> Result<(), Error> {
         let status = self
             .0

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -51,7 +51,7 @@
 //! }
 //! ```
 
-use std::os::fd::BorrowedFd;
+use std::os::fd::AsFd;
 
 use url::Url;
 use zbus::zvariant::{Fd, SerializeDict, Type};
@@ -87,7 +87,7 @@ impl<'a> OpenURIProxy<'a> {
     pub async fn open_directory(
         &self,
         identifier: Option<&WindowIdentifier>,
-        directory: &BorrowedFd<'_>,
+        directory: &impl AsFd,
         options: OpenDirOptions,
     ) -> Result<Request<()>, Error> {
         let identifier = identifier.map(|i| i.to_string()).unwrap_or_default();
@@ -103,7 +103,7 @@ impl<'a> OpenURIProxy<'a> {
     pub async fn open_file(
         &self,
         identifier: Option<&WindowIdentifier>,
-        file: &BorrowedFd<'_>,
+        file: &impl AsFd,
         options: OpenFileOptions,
     ) -> Result<Request<()>, Error> {
         let identifier = identifier.map(|i| i.to_string()).unwrap_or_default();
@@ -185,7 +185,7 @@ impl OpenFileRequest {
     }
 
     /// Send the request for a file.
-    pub async fn send_file(self, file: &BorrowedFd<'_>) -> Result<Request<()>, Error> {
+    pub async fn send_file(self, file: &impl AsFd) -> Result<Request<()>, Error> {
         let proxy = OpenURIProxy::new().await?;
         proxy
             .open_file(self.identifier.as_ref(), file, self.options)
@@ -231,7 +231,7 @@ impl OpenDirectoryRequest {
     }
 
     /// Send the request.
-    pub async fn send(self, directory: &BorrowedFd<'_>) -> Result<Request<()>, Error> {
+    pub async fn send(self, directory: &impl AsFd) -> Result<Request<()>, Error> {
         let proxy = OpenURIProxy::new().await?;
         proxy
             .open_directory(self.identifier.as_ref(), directory, self.options)

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -31,7 +31,7 @@
 //! }
 //! ```
 
-use std::{fmt, os::fd::BorrowedFd, str::FromStr};
+use std::{fmt, os::fd::AsFd, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::{DeserializeDict, Fd, SerializeDict, Type};
@@ -698,7 +698,7 @@ impl<'a> PrintProxy<'a> {
         &self,
         identifier: Option<&WindowIdentifier>,
         title: &str,
-        fd: &BorrowedFd<'_>,
+        fd: &impl AsFd,
         token: Option<u32>,
         modal: bool,
     ) -> Result<Request<()>, Error> {

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -18,7 +18,7 @@
 //! }
 //! ```
 
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::fd::AsFd;
 
 #[cfg(feature = "async-std")]
 use async_net::unix::UnixStream;
@@ -68,7 +68,7 @@ impl<'a> Secret<'a> {
     ///
     /// See also [`RetrieveSecret`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html#org-freedesktop-portal-secret-retrievesecret)
     #[doc(alias = "RetrieveSecret")]
-    pub async fn retrieve(&self, fd: &BorrowedFd<'_>) -> Result<Request<()>, Error> {
+    pub async fn retrieve(&self, fd: &impl AsFd) -> Result<Request<()>, Error> {
         let options = RetrieveOptions::default();
         self.0
             .empty_request(

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -30,7 +30,7 @@
 //! }
 //! ```
 
-use std::os::fd::BorrowedFd;
+use std::os::fd::AsFd;
 
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zbus::zvariant::{Fd, Type};
@@ -71,7 +71,7 @@ impl<'a> TrashProxy<'a> {
     /// See also [`TrashFile`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Trash.html#org-freedesktop-portal-trash-trashfile).
     #[doc(alias = "TrashFile")]
     #[doc(alias = "xdp_portal_trash_file")]
-    pub async fn trash_file(&self, fd: &BorrowedFd<'_>) -> Result<(), Error> {
+    pub async fn trash_file(&self, fd: &impl AsFd) -> Result<(), Error> {
         let status = self.0.call("TrashFile", &(Fd::from(fd))).await?;
         match status {
             TrashStatus::Failed => Err(Error::Portal(PortalError::Failed(
@@ -92,7 +92,7 @@ impl<'a> std::ops::Deref for TrashProxy<'a> {
 
 #[doc(alias = "xdp_portal_trash_file")]
 /// A handy wrapper around [`TrashProxy::trash_file`].
-pub async fn trash_file(fd: &BorrowedFd<'_>) -> Result<(), Error> {
+pub async fn trash_file(fd: &impl AsFd) -> Result<(), Error> {
     let proxy = TrashProxy::new().await?;
     proxy.trash_file(fd).await
 }

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -39,7 +39,7 @@
 //! }
 //! ```
 
-use std::{fmt, os::fd::BorrowedFd, str::FromStr};
+use std::{fmt, os::fd::AsFd, str::FromStr};
 
 use serde::{self, Deserialize, Serialize};
 use zbus::zvariant::{Fd, SerializeDict, Type};
@@ -126,7 +126,7 @@ impl<'a> WallpaperProxy<'a> {
     pub async fn set_wallpaper_file(
         &self,
         identifier: Option<&WindowIdentifier>,
-        file: &BorrowedFd<'_>,
+        file: &impl AsFd,
         options: WallpaperOptions,
     ) -> Result<Request<()>, Error> {
         let identifier = identifier.map(|i| i.to_string()).unwrap_or_default();
@@ -208,7 +208,7 @@ impl WallpaperRequest {
     }
 
     /// Build using a file.
-    pub async fn build_file(self, file: &BorrowedFd<'_>) -> Result<Request<()>, Error> {
+    pub async fn build_file(self, file: &impl AsFd) -> Result<Request<()>, Error> {
         let proxy = WallpaperProxy::new().await?;
         proxy
             .set_wallpaper_file(self.identifier.as_ref(), file, self.options)

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -22,7 +22,7 @@
 //! }
 //! ```
 
-use std::{collections::HashMap, os::fd::BorrowedFd};
+use std::{collections::HashMap, os::fd::AsFd};
 
 use futures_util::Stream;
 use zbus::zvariant::{Fd, SerializeDict, Type, Value};
@@ -98,7 +98,7 @@ impl<'a> FileTransfer<'a> {
     ///
     /// See also [`AddFiles`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileTransfer.html#org-freedesktop-portal-filetransfer-addfiles).
     #[doc(alias = "AddFiles")]
-    pub async fn add_files(&self, key: &str, fds: &[&BorrowedFd<'_>]) -> Result<(), Error> {
+    pub async fn add_files(&self, key: &str, fds: &[impl AsFd]) -> Result<(), Error> {
         // `options` parameter doesn't seems to be used yet
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         let files: Vec<Fd> = fds.iter().map(Fd::from).collect();

--- a/src/documents/mod.rs
+++ b/src/documents/mod.rs
@@ -33,7 +33,7 @@
 //! }
 //! ```
 
-use std::{collections::HashMap, fmt, os::fd::BorrowedFd, path::Path, str::FromStr};
+use std::{collections::HashMap, fmt, os::fd::AsFd, path::Path, str::FromStr};
 
 use enumflags2::{bitflags, BitFlags};
 use serde::{Deserialize, Serialize};
@@ -178,7 +178,7 @@ impl<'a> Documents<'a> {
     #[doc(alias = "Add")]
     pub async fn add(
         &self,
-        o_path_fd: &BorrowedFd<'_>,
+        o_path_fd: &impl AsFd,
         reuse_existing: bool,
         persistent: bool,
     ) -> Result<DocumentID, Error> {
@@ -213,7 +213,7 @@ impl<'a> Documents<'a> {
     #[doc(alias = "AddFull")]
     pub async fn add_full(
         &self,
-        o_path_fds: &[&BorrowedFd<'_>],
+        o_path_fds: &[impl AsFd],
         flags: BitFlags<DocumentFlags>,
         app_id: Option<&AppID>,
         permissions: &[Permission],
@@ -246,7 +246,7 @@ impl<'a> Documents<'a> {
     #[doc(alias = "AddNamed")]
     pub async fn add_named(
         &self,
-        o_path_parent_fd: &BorrowedFd<'_>,
+        o_path_parent_fd: &impl AsFd,
         filename: impl AsRef<Path>,
         reuse_existing: bool,
         persistent: bool,
@@ -292,7 +292,7 @@ impl<'a> Documents<'a> {
     #[doc(alias = "AddNamedFull")]
     pub async fn add_named_full(
         &self,
-        o_path_fd: &BorrowedFd<'_>,
+        o_path_fd: &impl AsFd,
         filename: impl AsRef<Path>,
         flags: BitFlags<DocumentFlags>,
         app_id: Option<&AppID>,

--- a/src/flatpak/development.rs
+++ b/src/flatpak/development.rs
@@ -2,7 +2,7 @@
 //! access to the session helper, spawn a process on the host, outside any
 //! sandbox.
 
-use std::{collections::HashMap, os::fd::BorrowedFd, path::Path};
+use std::{collections::HashMap, os::fd::AsFd, path::Path};
 
 use enumflags2::{bitflags, BitFlags};
 use futures_util::Stream;
@@ -75,7 +75,7 @@ impl<'a> Development<'a> {
         &self,
         cwd_path: impl AsRef<Path>,
         argv: &[impl AsRef<Path>],
-        fds: HashMap<u32, BorrowedFd<'_>>,
+        fds: HashMap<u32, impl AsFd>,
         envs: HashMap<&str, &str>,
         flags: BitFlags<HostCommandFlags>,
     ) -> Result<u32, Error> {

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -4,17 +4,19 @@
 //!
 //! ```rust,no_run
 //! use std::collections::HashMap;
+//! use std::os::fd::BorrowedFd;
 //!
 //! use ashpd::flatpak::{Flatpak, SpawnFlags, SpawnOptions};
 //!
 //! async fn run() -> ashpd::Result<()> {
 //!     let proxy = Flatpak::new().await?;
+//!     let fds: HashMap::<_, BorrowedFd<'_>> = HashMap::new();
 //!
 //!     proxy
 //!         .spawn(
 //!             "/",
 //!             &["contrast"],
-//!             HashMap::new(),
+//!             fds,
 //!             HashMap::new(),
 //!             SpawnFlags::ClearEnv | SpawnFlags::NoNetwork,
 //!             SpawnOptions::default(),
@@ -28,7 +30,7 @@
 use std::{
     collections::HashMap,
     fmt::Debug,
-    os::fd::{BorrowedFd, OwnedFd},
+    os::fd::{AsFd, OwnedFd},
     path::Path,
 };
 
@@ -325,7 +327,7 @@ impl<'a> Flatpak<'a> {
         &self,
         cwd_path: impl AsRef<Path>,
         argv: &[impl AsRef<Path>],
-        fds: HashMap<u32, BorrowedFd<'_>>,
+        fds: HashMap<u32, impl AsFd>,
         envs: HashMap<&str, &str>,
         flags: BitFlags<SpawnFlags>,
         options: SpawnOptions,


### PR DESCRIPTION
This is more general, in particular the following will still compile.

```rust
let fd = something_implementing_as_fd;
let fd: &std::os::fd::BorrowedFd<'_> = &fd.as_fd();
ashpd::any_method_using_a_fd(fd).await?;
```