### PR TITLE
Misc gtk4 fixes

### DIFF
--- a/ashpd-demo/Cargo.toml
+++ b/ashpd-demo/Cargo.toml
@@ -12,8 +12,8 @@ chrono = {version = "0.4", default-features = false, features = ["clock"]}
 futures-util = "0.3"
 gettext-rs = {version = "0.7", features = ["gettext-system"]}
 gst = {package = "gstreamer", version = "0.22"}
-gst4gtk = {package = "gst-plugin-gtk4", version = "0.12", features = ["wayland", "x11egl", "x11glx", "gtk_v4_14"]}
-gtk = {package = "gtk4", version = "0.8", features = ["v4_14"]}
+gst4gtk = {package = "gst-plugin-gtk4", version = "0.12", features = ["wayland", "x11egl", "x11glx", "gtk_v4_12"]}
+gtk = {package = "gtk4", version = "0.8", features = ["v4_12"]}
 serde = {version = "1.0", features = ["derive"]}
 shumate = {version = "0.5", package = "libshumate"}
 tracing = "0.1"

--- a/ashpd-demo/data/resources/ui/window.ui
+++ b/ashpd-demo/data/resources/ui/window.ui
@@ -174,6 +174,7 @@
         </property>
         <property name="content">
           <object class="AdwNavigationPage">
+            <property name="title"> </property>
             <property name="child">
               <object class="AdwToolbarView">
                 <child type="top">


### PR DESCRIPTION
There is no reason to require Gtk 4.14 but to prevent building on Fedora 39 (or other recent distros).

Also fix a warning: 

```
(ashpd-demo:1693266): Adwaita-WARNING **: 20:36:20.845: AdwNavigationPage 0x55c88967d080 is missing a title. To hide a header bar title, consider using AdwHeaderBar:show-title instead.
```