### PR TITLE
cargo: Update to gtk4-rs 0.9 and core 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ async-net = { version = "2.0.0", optional = true }
 enumflags2 = "0.7"
 futures-channel = "0.3"
 futures-util = "0.3"
-gdk4wayland = { package = "gdk4-wayland", version = "0.8", optional = true }
-gdk4x11 = { package = "gdk4-x11", version = "0.8", optional = true }
-glib = { version = "0.19", optional = true }
-gtk4 = { version = "0.8", optional = true }
+gdk4wayland = { package = "gdk4-wayland", version = "0.9", optional = true, git = "https://github.com/gtk-rs/gtk4-rs.git", branch = "master" }
+gdk4x11 = { package = "gdk4-x11", version = "0.9", optional = true, git = "https://github.com/gtk-rs/gtk4-rs.git", branch = "master" }
+glib = { version = "0.20", optional = true, git = "https://github.com/gtk-rs/gtk-rs-core.git", branch = "master" }
+gtk4 = { version = "0.9", optional = true, git = "https://github.com/gtk-rs/gtk4-rs.git", branch = "master" }
 pipewire = { version = "0.8", optional = true }
 rand = { version = "0.8", default-features = false }
 raw-window-handle = { version = "0.6", optional = true }
@@ -55,7 +55,7 @@ zbus = { version = "4.0", default-features = false, features = ["url"] }
 
 [dev-dependencies]
 serde_json = "1.0"
-reis = { version = "0.2.0", features = [ "tokio" ] }
+reis = { version = "0.2.0", features = ["tokio"] }
 
 [package.metadata.docs.rs]
 features = ["gtk4", "raw_handle"]


### PR DESCRIPTION
Not sure if you want to merge this. Created it because I need a branch that works with gtk-rs master