### PR TITLE
fix barrier_id=0 in input-capture example

### DIFF
--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -106,7 +106,7 @@
 //!         .iter()
 //!         .enumerate()
 //!         .map(|(n, r)| {
-//!             let id = n as u32;
+//!             let id = (n + 1) as u32;
 //!             let (x, y) = (r.x_offset(), r.y_offset());
 //!             let (width, height) = (r.width() as i32, r.height() as i32);
 //!             let barrier_pos = match pos {
@@ -217,7 +217,7 @@
 //!         .iter()
 //!         .enumerate()
 //!         .map(|(n, r)| {
-//!             let id = n as u32;
+//!             let id = (n + 1) as u32;
 //!             let (x, y) = (r.x_offset(), r.y_offset());
 //!             let (width, height) = (r.width() as i32, r.height() as i32);
 //!             let barrier_pos = match pos {

--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -79,7 +79,7 @@
 //! and returned in the `failed_barrier_ids` vector.
 //!
 //! ```rust,no_run
-//! use ashpd::desktop::input_capture::{Barrier, Capabilities, InputCapture};
+//! use ashpd::desktop::input_capture::{Barrier, BarrierID, Capabilities, InputCapture};
 //!
 //! #[allow(unused)]
 //! enum Position {
@@ -106,7 +106,7 @@
 //!         .iter()
 //!         .enumerate()
 //!         .map(|(n, r)| {
-//!             let id = (n + 1) as u32;
+//!             let id = BarrierID::new((n + 1) as u32).expect("barrier-id must be non-zero");
 //!             let (x, y) = (r.x_offset(), r.y_offset());
 //!             let (width, height) = (r.width() as i32, r.height() as i32);
 //!             let barrier_pos = match pos {
@@ -143,7 +143,7 @@
 //! ```rust,no_run
 //! use std::{collections::HashMap, os::unix::net::UnixStream, sync::OnceLock, time::Duration};
 //!
-//! use ashpd::desktop::input_capture::{Barrier, Capabilities, InputCapture};
+//! use ashpd::desktop::input_capture::{Barrier, BarrierID, Capabilities, InputCapture};
 //! use futures_util::StreamExt;
 //! use reis::{
 //!     ei::{self, keyboard::KeyState},
@@ -217,7 +217,7 @@
 //!         .iter()
 //!         .enumerate()
 //!         .map(|(n, r)| {
-//!             let id = (n + 1) as u32;
+//!             let id = BarrierID::new((n + 1) as u32).expect("barrier-id must be non-zero");
 //!             let (x, y) = (r.x_offset(), r.y_offset());
 //!             let (width, height) = (r.width() as i32, r.height() as i32);
 //!             let barrier_pos = match pos {

--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -435,9 +435,8 @@ impl Activated {
     }
 }
 
-#[derive(zvariant::Type)]
+#[derive(Clone, Copy, Debug, Type)]
 #[zvariant(signature = "u")]
-#[derive(Clone, Copy, Debug)]
 /// information about an activation barrier
 pub enum ActivatedBarrier {
     /// [`BarrierID`] of the triggered barrier


### PR DESCRIPTION
According to the documentation, barrier-ids must be non-zero.

(https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.InputCapture.html#org-freedesktop-portal-inputcapture-setpointerbarriers)