### PR TITLE
make activation-options optional

### DIFF
--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -402,9 +402,9 @@ impl Deactivated {
 #[derive(Debug, DeserializeDict, Type)]
 #[zvariant(signature = "dict")]
 struct ActivatedOptions {
-    activation_id: u32,
-    cursor_position: (f32, f32),
-    barrier_id: BarrierID,
+    activation_id: Option<u32>,
+    cursor_position: Option<(f32, f32)>,
+    barrier_id: Option<BarrierID>,
 }
 
 /// Indicates that an input capturing session was activated.
@@ -419,17 +419,17 @@ impl Activated {
     }
 
     /// A number that can be used to synchronize with the transport-layer.
-    pub fn activation_id(&self) -> u32 {
+    pub fn activation_id(&self) -> Option<u32> {
         self.1.activation_id
     }
 
     /// The current cursor position in the same coordinate space as the zones.
-    pub fn cursor_position(&self) -> (f32, f32) {
+    pub fn cursor_position(&self) -> Option<(f32, f32)> {
         self.1.cursor_position
     }
 
     /// The barrier id of the barrier that triggered
-    pub fn barrier_id(&self) -> BarrierID {
+    pub fn barrier_id(&self) -> Option<BarrierID> {
         self.1.barrier_id
     }
 }

--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -275,7 +275,7 @@
 //!         }
 //!
 //!         eprintln!("releasing input capture");
-//!         let (x, y) = activated.cursor_position();
+//!         let (x, y) = activated.cursor_position().unwrap();
 //!         let (x, y) = (x as f64, y as f64);
 //!         let cursor_pos = match pos {
 //!             Position::Left => (x + 1., y),
@@ -284,7 +284,7 @@
 //!             Position::Bottom => (x, y + 1.),
 //!         };
 //!         input_capture
-//!             .release(&session, activated.activation_id(), cursor_pos)
+//!             .release(&session, activated.activation_id().unwrap(), cursor_pos)
 //!             .await?;
 //!     }
 //! }


### PR DESCRIPTION
The spec states "options - Vardict with **_optional_** further information".

As of right now, the KDE portal does not send a `barrier_id` in the Activated signal, which breaks deserialization...


I'm proposing this change, which makes all of the fields optional.

Technically this implementation is also wrong with most other signals, but let me know, what you think about this.