### PR TITLE
Allow setting activation_token in supported portals

### DIFF
--- a/src/activation_token/mod.rs
+++ b/src/activation_token/mod.rs
@@ -1,0 +1,48 @@
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use zbus::zvariant::Type;
+
+/// A token that can be used to activate an application.
+///
+/// No guarantees are made for the token structure.
+#[derive(Debug, Deserialize, Serialize, Type, PartialEq, Eq, Hash, Clone)]
+pub struct ActivationToken(String);
+
+impl From<String> for ActivationToken {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for ActivationToken {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<ActivationToken> for String {
+    fn from(value: ActivationToken) -> String {
+        value.0
+    }
+}
+
+impl Deref for ActivationToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for ActivationToken {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl std::fmt::Display for ActivationToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -30,7 +30,7 @@ use serde::Serialize;
 use zbus::zvariant::{self, SerializeDict, Type};
 
 use super::{HandleToken, Request};
-use crate::{proxy::Proxy, Error, WindowIdentifier};
+use crate::{proxy::Proxy, ActivationToken, Error, WindowIdentifier};
 
 #[derive(SerializeDict, Type, Debug, Default)]
 #[zvariant(signature = "dict")]
@@ -43,8 +43,7 @@ struct EmailOptions {
     subject: Option<String>,
     body: Option<String>,
     attachment_fds: Option<Vec<zvariant::OwnedFd>>,
-    // TODO Expose activation_token in the api
-    activation_token: Option<String>,
+    activation_token: Option<ActivationToken>,
 }
 
 #[derive(Debug)]
@@ -178,11 +177,13 @@ impl EmailRequest {
     }
 
     // TODO Added in version 4 of the interface.
-    /// Sets the activation token.
-    #[allow(dead_code)]
+    /// Sets the token that can be used to activate the chosen application.
     #[must_use]
-    fn activation_token<'a>(mut self, activation_token: impl Into<Option<&'a str>>) -> Self {
-        self.options.activation_token = activation_token.into().map(ToOwned::to_owned);
+    pub fn activation_token(
+        mut self,
+        activation_token: impl Into<Option<ActivationToken>>,
+    ) -> Self {
+        self.options.activation_token = activation_token.into();
         self
     }
 

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -57,13 +57,13 @@ use url::Url;
 use zbus::zvariant::{Fd, SerializeDict, Type};
 
 use super::{HandleToken, Request};
-use crate::{proxy::Proxy, Error, WindowIdentifier};
+use crate::{proxy::Proxy, ActivationToken, Error, WindowIdentifier};
 
 #[derive(SerializeDict, Type, Debug, Default)]
 #[zvariant(signature = "dict")]
 struct OpenDirOptions {
     handle_token: HandleToken,
-    activation_token: Option<String>,
+    activation_token: Option<ActivationToken>,
 }
 
 #[derive(SerializeDict, Type, Debug, Default)]
@@ -72,7 +72,7 @@ struct OpenFileOptions {
     handle_token: HandleToken,
     writeable: Option<bool>,
     ask: Option<bool>,
-    activation_token: Option<String>,
+    activation_token: Option<ActivationToken>,
 }
 
 #[derive(Debug)]
@@ -171,6 +171,16 @@ impl OpenFileRequest {
         self
     }
 
+    /// Sets the token that can be used to activate the chosen application.
+    #[must_use]
+    pub fn activation_token(
+        mut self,
+        activation_token: impl Into<Option<ActivationToken>>,
+    ) -> Self {
+        self.options.activation_token = activation_token.into();
+        self
+    }
+
     /// Send the request for a file.
     pub async fn send_file(self, file: &BorrowedFd<'_>) -> Result<Request<()>, Error> {
         let proxy = OpenURIProxy::new().await?;
@@ -200,6 +210,16 @@ impl OpenDirectoryRequest {
     /// Sets a window identifier.
     pub fn identifier(mut self, identifier: impl Into<Option<WindowIdentifier>>) -> Self {
         self.identifier = identifier.into().unwrap_or_default();
+        self
+    }
+
+    /// Sets the token that can be used to activate the chosen application.
+    #[must_use]
+    pub fn activation_token(
+        mut self,
+        activation_token: impl Into<Option<ActivationToken>>,
+    ) -> Self {
+        self.options.activation_token = activation_token.into();
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 static IS_SANDBOXED: OnceLock<bool> = OnceLock::new();
 
+mod activation_token;
 /// Interact with the user's desktop such as taking a screenshot, setting a
 /// background or querying the user's location.
 pub mod desktop;
@@ -22,6 +23,7 @@ pub mod documents;
 mod error;
 mod window_identifier;
 
+pub use self::activation_token::ActivationToken;
 pub use self::window_identifier::WindowIdentifier;
 mod app_id;
 pub use self::app_id::AppID;


### PR DESCRIPTION
Allow manually setting the `activation_token` option for the [OpenURI](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html) and [DynamicLauncher.Launch](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.DynamicLauncher.html#org-freedesktop-portal-dynamiclauncher-launch) portals.

I saw that https://github.com/bilelmoussaoui/ashpd/pull/70 is opened but it also includes additional integration, while this just allows setting the token if we already got it from somewhere else (e.g. directly via the Wayland protocol)

(related commit: https://github.com/apricotbucket28/zed/commit/15489a03966b1c627c9596e0635c5f45c9411b9e)
