### PR TITLE
file_chooser: Make choices optional

### DIFF
--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -233,7 +233,7 @@ struct OpenFileOptions {
     directory: Option<bool>,
     filters: Vec<FileFilter>,
     current_filter: Option<FileFilter>,
-    choices: Vec<Choice>,
+    choices: Option<Vec<Choice>>,
     current_folder: Option<FilePath>,
 }
 
@@ -248,7 +248,7 @@ struct SaveFileOptions {
     current_file: Option<FilePath>,
     filters: Vec<FileFilter>,
     current_filter: Option<FileFilter>,
-    choices: Vec<Choice>,
+    choices: Option<Vec<Choice>>,
 }
 
 #[derive(SerializeDict, Type, Debug, Default)]
@@ -257,7 +257,7 @@ struct SaveFilesOptions {
     handle_token: HandleToken,
     accept_label: Option<String>,
     modal: Option<bool>,
-    choices: Vec<Choice>,
+    choices: Option<Vec<Choice>>,
     current_folder: Option<FilePath>,
     files: Option<Vec<FilePath>>,
 }
@@ -440,14 +440,17 @@ impl OpenFileRequest {
     /// Adds a choice.
     #[must_use]
     pub fn choice(mut self, choice: Choice) -> Self {
-        self.options.choices.push(choice);
+        self.options
+            .choices
+            .get_or_insert_with(Vec::new)
+            .push(choice);
         self
     }
 
     #[must_use]
     /// Adds a list of choices.
     pub fn choices(mut self, choices: impl IntoIterator<Item = Choice>) -> Self {
-        self.options.choices = choices.into_iter().collect();
+        self.options.choices = Some(choices.into_iter().collect());
         self
     }
 
@@ -515,14 +518,17 @@ impl SaveFilesRequest {
     /// Adds a choice.
     #[must_use]
     pub fn choice(mut self, choice: Choice) -> Self {
-        self.options.choices.push(choice);
+        self.options
+            .choices
+            .get_or_insert_with(Vec::new)
+            .push(choice);
         self
     }
 
     #[must_use]
     /// Adds a list of choices.
     pub fn choices(mut self, choices: impl IntoIterator<Item = Choice>) -> Self {
-        self.options.choices = choices.into_iter().collect();
+        self.options.choices = Some(choices.into_iter().collect());
         self
     }
 
@@ -651,14 +657,17 @@ impl SaveFileRequest {
     /// Adds a choice.
     #[must_use]
     pub fn choice(mut self, choice: Choice) -> Self {
-        self.options.choices.push(choice);
+        self.options
+            .choices
+            .get_or_insert_with(Vec::new)
+            .push(choice);
         self
     }
 
     #[must_use]
     /// Adds a list of choices.
     pub fn choices(mut self, choices: impl IntoIterator<Item = Choice>) -> Self {
-        self.options.choices = choices.into_iter().collect();
+        self.options.choices = Some(choices.into_iter().collect());
         self
     }
 


### PR DESCRIPTION
While investigating why the open directory dialogs in Zed weren't the same as other GTK programs and Chromium, I noticed that the dbus message ashpd sent had an empty choices array (even though Zed didn't set any choices itself). Making the choices optional so ashpd wouldn't send them fixed the problem.

This is probably a KDE quirk; but the [file chooser](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html) portal documentation states:
> As a special case, passing an empty array for the list of choices indicates a boolean choice that is typically displayed as a check button, using “true” and “false” as the choices.

So it's probably a good idea to make them optional.

To clarify, this is what dialogs looked like before:
![image](https://github.com/user-attachments/assets/cff534e2-522d-4bd5-baed-a86e031a00e7)

And this is how they look now:
![image](https://github.com/user-attachments/assets/780bec6d-4b10-4ccb-9efe-f707e4568c4e)
