### PR TITLE
activation_token: Provide GTK 4 helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ futures-util = "0.3"
 gdk4wayland = { package = "gdk4-wayland", version = "0.9", optional = true }
 gdk4x11 = { package = "gdk4-x11", version = "0.9", optional = true }
 glib = { version = "0.20", optional = true }
-gtk4 = { version = "0.9", optional = true }
+gtk4 = { version = "0.9.3", optional = true }
 pipewire = { version = "0.8", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 raw-window-handle = { version = "0.6", optional = true }

--- a/src/activation_token/gtk4.rs
+++ b/src/activation_token/gtk4.rs
@@ -1,0 +1,42 @@
+use glib::translate::from_glib_full;
+use gtk4::{gio, prelude::*};
+
+use crate::ActivationToken;
+
+impl ActivationToken {
+    /// Gets an activation token from a window.
+    ///
+    /// Support for the XDG Activation Protocol was added in GLib 2.76, this
+    /// method will return `None` on older versions.
+    pub fn from_window(widget: &impl IsA<::gtk4::Widget>) -> Option<Self> {
+        if glib::check_version(2, 76, 0).is_some() {
+            #[cfg(feature = "tracing")]
+            tracing::info!("Need glib 2.76 for XDG Activation protocol support");
+
+            return None;
+        }
+
+        let display = widget.as_ref().display();
+        let context = display.app_launch_context();
+
+        // g_app_launch_context_get_startup_notify_id only accepts nullable
+        // parameters since 2.82. On older versions we use the vfunc.
+        if glib::check_version(2, 82, 0).is_some() {
+            unsafe {
+                let klass: *mut gtk4::gio::ffi::GAppLaunchContextClass =
+                    std::ptr::addr_of!((*context.class().parent()?)) as *mut _;
+                let get_startup_notify_id = (*klass).get_startup_notify_id.as_ref()?;
+                from_glib_full::<_, Option<String>>(get_startup_notify_id(
+                    context.as_ptr().cast(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                ))
+            }
+        } else {
+            context
+                .startup_notify_id(gio::AppInfo::NONE, &[])
+                .map(String::from)
+        }
+        .map(Self::from)
+    }
+}

--- a/src/activation_token/mod.rs
+++ b/src/activation_token/mod.rs
@@ -3,6 +3,9 @@ use std::ops::Deref;
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::Type;
 
+#[cfg(any(feature = "gtk4_wayland", feature = "gtk4_x11"))]
+mod gtk4;
+
 /// A token that can be used to activate an application.
 ///
 /// No guarantees are made for the token structure.


### PR DESCRIPTION
cc @jsparber

I noticed that `cargo clippy --features=gtk4 -- -W clippy::pedantic` will complain:

```
warning: casting from `*const glib::Class<gtk4::gdk4::AppLaunchContext>` to a more-strictly-aligned pointer (`*mut gtk4::gio::gio_sys::GAppLaunchContextClass`) (1 < 8 bytes)
  --> src/activation_token/mod.rs:63:17
   |
63 |                 std::ptr::addr_of!((*context.class().parent()?)) as *mut _;
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_ptr_alignment
   = note: `-W clippy::cast-ptr-alignment` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::cast_ptr_alignment)]`
```