### PR TITLE
dynamic_laucher: Fix textview style

### DIFF
--- a/ashpd-demo/data/resources/ui/dynamic_launcher.ui
+++ b/ashpd-demo/data/resources/ui/dynamic_launcher.ui
@@ -76,11 +76,18 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkTextView" id="desktop_file_content">
+                  <object class="AdwBin">
                     <property name="margin-top">12</property>
                     <style>
                       <class name="card" />
                     </style>
+                    <child>
+                      <object class="GtkTextView" id="desktop_file_content">
+                        <style>
+                          <class name="inline" />
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
We need `.inline` to remove the `.view`'s background, but card and inline can't be on the same widget as card adds a background.

![image](https://github.com/user-attachments/assets/c19cb9ff-a961-4a4e-b7b3-7d2ed12f073c)
