### PR TITLE
desktop/game_mode: Use `i32` for pid

### DIFF
--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use zbus::zvariant::{SerializeDict, Type};
 
 use super::{HandleToken, Request};
-use crate::{proxy::Proxy, Error};
+use crate::{proxy::Proxy, Error, Pid};
 
 #[derive(SerializeDict, Type, Debug, Default)]
 /// Specified options for a [`DeviceProxy::access_device`] request.
@@ -124,7 +124,7 @@ impl<'a> DeviceProxy<'a> {
     ///
     /// See also [`AccessDevice`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Device.html#org-freedesktop-portal-device-accessdevice).
     #[doc(alias = "AccessDevice")]
-    pub async fn access_device(&self, pid: u32, devices: &[Device]) -> Result<Request<()>, Error> {
+    pub async fn access_device(&self, pid: Pid, devices: &[Device]) -> Result<Request<()>, Error> {
         let options = AccessDeviceOptions::default();
         self.0
             .empty_request(

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -20,7 +20,7 @@ use std::{fmt::Debug, os::fd::BorrowedFd};
 use serde_repr::Deserialize_repr;
 use zbus::zvariant::{Fd, Type};
 
-use crate::{error::PortalError, proxy::Proxy, Error};
+use crate::{error::PortalError, proxy::Proxy, Error, Pid};
 
 #[cfg_attr(feature = "glib", derive(glib::Enum))]
 #[cfg_attr(feature = "glib", enum_type(name = "AshpdGameModeStatus"))]
@@ -95,8 +95,8 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`QueryStatus`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-querystatus).
     #[doc(alias = "QueryStatus")]
-    pub async fn query_status(&self, pid: u32) -> Result<Status, Error> {
-        self.0.call("QueryStatus", &(pid)).await
+    pub async fn query_status(&self, pid: Pid) -> Result<Status, Error> {
+        self.0.call("QueryStatus", &(pid as i32)).await
     }
 
     /// Query the GameMode status for a process.
@@ -135,8 +135,10 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`QueryStatusByPid`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-querystatusbypid).
     #[doc(alias = "QueryStatusByPid")]
-    pub async fn query_status_by_pid(&self, target: u32, requester: u32) -> Result<Status, Error> {
-        self.0.call("QueryStatusByPid", &(target, requester)).await
+    pub async fn query_status_by_pid(&self, target: Pid, requester: Pid) -> Result<Status, Error> {
+        self.0
+            .call("QueryStatusByPid", &(target as i32, requester as i32))
+            .await
     }
 
     /// Register a game with GameMode and thus request GameMode to be activated.
@@ -153,8 +155,8 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`RegisterGame`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-registergame).
     #[doc(alias = "RegisterGame")]
-    pub async fn register(&self, pid: u32) -> Result<(), Error> {
-        let status = self.0.call("RegisterGame", &(pid)).await?;
+    pub async fn register(&self, pid: Pid) -> Result<(), Error> {
+        let status = self.0.call("RegisterGame", &(pid as i32)).await?;
         match status {
             RegisterStatus::Success => Ok(()),
             RegisterStatus::Rejected => Err(Error::Portal(PortalError::Failed(format!(
@@ -206,10 +208,10 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`RegisterGameByPid`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-registergamebypid).
     #[doc(alias = "RegisterGameByPid")]
-    pub async fn register_by_pid(&self, target: u32, requester: u32) -> Result<(), Error> {
+    pub async fn register_by_pid(&self, target: Pid, requester: Pid) -> Result<(), Error> {
         let status = self
             .0
-            .call("RegisterGameByPid", &(target, requester))
+            .call("RegisterGameByPid", &(target as i32, requester as i32))
             .await?;
         match status {
             RegisterStatus::Success => Ok(()),
@@ -233,8 +235,8 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`UnregisterGame`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-unregistergame).
     #[doc(alias = "UnregisterGame")]
-    pub async fn unregister(&self, pid: u32) -> Result<(), Error> {
-        let status = self.0.call("UnregisterGame", &(pid)).await?;
+    pub async fn unregister(&self, pid: Pid) -> Result<(), Error> {
+        let status = self.0.call("UnregisterGame", &(pid as i32)).await?;
         match status {
             RegisterStatus::Success => Ok(()),
             RegisterStatus::Rejected => Err(Error::Portal(PortalError::Failed(format!(
@@ -287,10 +289,10 @@ impl<'a> GameMode<'a> {
     ///
     /// See also [`UnregisterGameByPid`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html#org-freedesktop-portal-gamemode-unregistergamebypid).
     #[doc(alias = "UnregisterGameByPid")]
-    pub async fn unregister_by_pid(&self, target: u32, requester: u32) -> Result<(), Error> {
+    pub async fn unregister_by_pid(&self, target: Pid, requester: Pid) -> Result<(), Error> {
         let status = self
             .0
-            .call("UnregisterGameByPid", &(target, requester))
+            .call("UnregisterGameByPid", &(target as i32, requester as i32))
             .await?;
         match status {
             RegisterStatus::Success => Ok(()),

--- a/src/flatpak/development.rs
+++ b/src/flatpak/development.rs
@@ -9,7 +9,7 @@ use futures_util::Stream;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zbus::zvariant::{Fd, Type};
 
-use crate::{proxy::Proxy, Error, FilePath};
+use crate::{proxy::Proxy, Error, FilePath, Pid};
 
 #[bitflags]
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Copy, Clone, Debug, Type)]
@@ -106,7 +106,7 @@ impl<'a> Development<'a> {
     #[doc(alias = "xdp_portal_spawn_signal")]
     pub async fn host_command_signal(
         &self,
-        pid: u32,
+        pid: Pid,
         signal: u32,
         to_process_group: bool,
     ) -> Result<(), Error> {

--- a/src/flatpak/mod.rs
+++ b/src/flatpak/mod.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zbus::zvariant::{self, Fd, OwnedObjectPath, SerializeDict, Type};
 
-use crate::{proxy::Proxy, Error, FilePath};
+use crate::{proxy::Proxy, Error, FilePath, Pid};
 
 #[bitflags]
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Copy, Clone, Debug, Type)]
@@ -357,7 +357,7 @@ impl<'a> Flatpak<'a> {
     #[doc(alias = "xdp_portal_spawn_signal")]
     pub async fn spawn_signal(
         &self,
-        pid: u32,
+        pid: Pid,
         signal: u32,
         to_process_group: bool,
     ) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,3 +85,8 @@ mod sealed {
 }
 
 pub(crate) use sealed::Sealed;
+
+/// Process ID.
+///
+/// Matches the type used in std.
+pub type Pid = u32;


### PR DESCRIPTION
As per the documentation, methods which accept pids (e.g. `RegisterGame`, `RegisterGameByPid`) require the type of pid to be `i` (`i32`), not `u` (`u32`).

Using `u32` causes errors in runtime, making these methods unusable. This bug was most likely introduced by ae81250.

See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html