### PR TITLE
desktop: Make trait SessionPortal public

### DIFF
--- a/src/desktop/global_shortcuts.rs
+++ b/src/desktop/global_shortcuts.rs
@@ -316,4 +316,5 @@ impl<'a> std::ops::Deref for GlobalShortcuts<'a> {
     }
 }
 
+impl crate::Sealed for GlobalShortcuts<'_> {}
 impl SessionPortal for GlobalShortcuts<'_> {}

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -251,4 +251,5 @@ impl<'a> std::ops::Deref for InhibitProxy<'a> {
     }
 }
 
+impl crate::Sealed for InhibitProxy<'_> {}
 impl SessionPortal for InhibitProxy<'_> {}

--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -732,4 +732,5 @@ impl<'a> std::ops::Deref for InputCapture<'a> {
     }
 }
 
+impl crate::Sealed for InputCapture<'_> {}
 impl SessionPortal for InputCapture<'_> {}

--- a/src/desktop/location.rs
+++ b/src/desktop/location.rs
@@ -285,6 +285,7 @@ impl<'a> LocationProxy<'a> {
     }
 }
 
+impl crate::Sealed for LocationProxy<'_> {}
 impl SessionPortal for LocationProxy<'_> {}
 
 impl<'a> std::ops::Deref for LocationProxy<'a> {

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -4,7 +4,7 @@ mod session;
 pub(crate) use self::handle_token::HandleToken;
 pub use self::{
     request::{Request, Response, ResponseError, ResponseType},
-    session::Session,
+    session::{Session, SessionPortal},
 };
 mod color;
 pub use color::Color;

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -695,4 +695,5 @@ impl<'a> std::ops::Deref for RemoteDesktop<'a> {
     }
 }
 
+impl crate::Sealed for RemoteDesktop<'_> {}
 impl SessionPortal for RemoteDesktop<'_> {}

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -424,6 +424,7 @@ impl<'a> std::ops::Deref for Screencast<'a> {
     }
 }
 
+impl crate::Sealed for Screencast<'_> {}
 impl SessionPortal for Screencast<'_> {}
 
 /// Defines which portals session can be used in a screen-cast.

--- a/src/desktop/session.rs
+++ b/src/desktop/session.rs
@@ -101,7 +101,7 @@ where
 }
 
 /// Portals that have a long-lived interaction
-pub trait SessionPortal {}
+pub trait SessionPortal: crate::Sealed {}
 
 /// A response to a `create_session` request.
 #[derive(Type, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,10 @@ pub async fn is_sandboxed() -> bool {
 }
 
 pub use self::error::{Error, PortalError};
+
+mod sealed {
+    /// Use as a supertrait for public traits that users should not be able to implement
+    pub trait Sealed {}
+}
+
+pub(crate) use sealed::Sealed;


### PR DESCRIPTION
Make the `SessionPortal` trait public so that users can use it in trait bounds.

For example I'd like to have a newtype around Session that calls `close` on Drop. Currently I can't do that in a generic way, because I can't use the trait as a bound since it's private.
```rust
struct CloseOnDrop<'s, Portal: ashpd::desktop::session::SessionPortal>(Session<'s, Portal>);

impl<P: ashpd::desktop::session::SessionPortal> Drop for CloseOnDrop<'_, P> {
    fn drop(&mut self) {
        pollster::block_on(self.0.close());
    }
}
```
```
error[E0603]: module `session` is private
   --> src/backend/connection.rs:192:25
    |
192 | impl<P: ashpd::desktop::session::SessionPortal> Drop for CloseOnDrop<'_, P> {
    |                         ^^^^^^^  ------------- trait `SessionPortal` is not publicly re-exported
    |                         |
    |                         private module
```
To solve this, I re-exported the `SessionPortal` trait in the `desktop` module.

Because that would make users be able to implement the trait on any struct, I used the [sealed trait](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#what-are-sealed-traits) trick.

I added `trait Sealed` the root lib.rs because I thought you may want to use this trick in the future for other traits in the library, but feel free to tell me if you prefer another location.