### PR TITLE
Use the crate from the repo and async-std

### DIFF
--- a/ashpd-demo/Cargo.lock
+++ b/ashpd-demo/Cargo.lock
@@ -44,9 +44,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "ashpd"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe7e0dd0ac5a401dc116ed9f9119cf9decc625600474cb41f0fc0a0050abc9a"
+version = "0.9.0"
 dependencies = [
  "async-fs",
  "async-net",

--- a/ashpd-demo/Cargo.toml
+++ b/ashpd-demo/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.4.1"
 [dependencies]
 adw = {version = "0.7", package = "libadwaita", features = ["v1_4"]}
 anyhow = "1.0"
-ashpd = {version = "^0.9", features = ["gtk4", "tracing", "pipewire"]}
+ashpd = {version = "^0.9", path = "..", default-features = false, features = ["gtk4", "tracing", "pipewire", "async-std"]}
 chrono = {version = "0.4", default-features = false, features = ["clock"]}
 futures-util = "0.3"
 gettext-rs = {version = "0.7", features = ["gettext-system"]}


### PR DESCRIPTION
1. so that we always build with the latest. 
2. fix feature so that it actually work.