### PR TITLE
fixup! activation_token: Provide GTK 4 helper

### DIFF
--- a/src/activation_token/gtk4.rs
+++ b/src/activation_token/gtk4.rs
@@ -24,7 +24,7 @@ impl ActivationToken {
         if glib::check_version(2, 82, 0).is_some() {
             unsafe {
                 let klass: *mut gtk4::gio::ffi::GAppLaunchContextClass =
-                    std::ptr::addr_of!((*context.class().parent()?)) as *mut _;
+                    &context.class().parent()? as *const _ as *mut _;
                 let get_startup_notify_id = (*klass).get_startup_notify_id.as_ref()?;
                 from_glib_full::<_, Option<String>>(get_startup_notify_id(
                     context.as_ptr().cast(),


### PR DESCRIPTION
Use as const as mut, this fixes a clippy lint that could have been seen with

    cargo clippy --features=gtk4 -- -W clippy::cast-ptr-alignment