### PR TITLE
rust: Run cargo +nightly fmt

### DIFF
--- a/ashpd-demo/src/application.rs
+++ b/ashpd-demo/src/application.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, convert::TryFrom};
+use std::{collections::HashMap, convert::TryFrom, str::FromStr};
 
 use adw::{prelude::*, subclass::prelude::*};
 use ashpd::{
@@ -179,7 +179,8 @@ impl Application {
 
         impl zvariant::DynamicType for Params {
             fn signature(&self) -> zvariant::Signature {
-                zvariant::Signature::from_str("(sava{sv})").unwrap() }
+                zvariant::Signature::from_str("(sava{sv})").unwrap()
+            }
         }
 
         proxy


### PR DESCRIPTION
I was told to run `cargo +nightly fmt` to format the code in my PR and this keeps popping.

(from commit b61d118bb3599c77ab7b0b5d9a6926e757fdc405)