### PR TITLE
demo: Allow to set file chooser filters

### DIFF
--- a/ashpd-demo/build-aux/com.belmoussaoui.ashpd.demo.Devel.json
+++ b/ashpd-demo/build-aux/com.belmoussaoui.ashpd.demo.Devel.json
@@ -42,7 +42,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libshumate/",
+                    "url": "https://gitlab.gnome.org/GNOME/libshumate.git",
                     "branch": "libshumate-1-3"
                 }
             ]

--- a/ashpd-demo/data/resources/ui/file_chooser.ui
+++ b/ashpd-demo/data/resources/ui/file_chooser.ui
@@ -37,6 +37,12 @@
                     <property name="title" translatable="yes">Directory</property>
                   </object>
                 </child>
+                <child>
+                  <object class="AdwComboRow" id="open_filter_combo">
+                    <property name="title" translatable="yes">Filters</property>
+                    <property name="model">filters</property>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
@@ -91,6 +97,12 @@
                 <child>
                   <object class="AdwEntryRow" id="save_file_current_folder_entry">
                     <property name="title" translatable="yes">Current Folder</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwComboRow" id="save_file_filter_combo">
+                    <property name="title" translatable="yes">Filters</property>
+                    <property name="model">filters</property>
                   </object>
                 </child>
               </object>
@@ -173,4 +185,12 @@
       </object>
     </child>
   </template>
+  <object class="GtkStringList" id="filters">
+    <items>
+      <item translatable="yes">No filter</item>
+      <item translatable="yes">Text files</item>
+      <item translatable="yes">Text files and images</item>
+      <item translatable="yes">Text files, images and videos</item>
+    </items>
+  </object>
 </interface>


### PR DESCRIPTION
Add a combox box that allows select different filters to the OpenFile and SaveFile dialogs. Adding different mime types allows for some flexibility when testing e.g. file choser implementations.
    
When a filter set of filters is selected we pick the first filter as the `current_filter`.
The default is no filters.

A separate commit avoids a redirect when cloning libshumate

Screenshot:

![filters](https://github.com/user-attachments/assets/2a6aa768-0ad6-4cce-9ebf-bea9dee2f083)
