### PR TITLE
backend: Pass handle token to method calls for easier identification and association with their backend logic

### DIFF
--- a/backend-demo/src/account.rs
+++ b/backend-demo/src/account.rs
@@ -4,7 +4,7 @@ use ashpd::{
         request::RequestImpl,
         Result,
     },
-    desktop::account::UserInformation,
+    desktop::{account::UserInformation, HandleToken},
     AppID, WindowIdentifierType,
 };
 use async_trait::async_trait;
@@ -39,6 +39,7 @@ mod fdo_account {
 impl AccountImpl for Account {
     async fn get_user_information(
         &self,
+        _token: HandleToken,
         _app_id: Option<AppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: UserInformationOptions,

--- a/backend-demo/src/account.rs
+++ b/backend-demo/src/account.rs
@@ -14,8 +14,8 @@ pub struct Account;
 
 #[async_trait]
 impl RequestImpl for Account {
-    async fn close(&self) {
-        tracing::debug!("IN Close()");
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
     }
 }
 

--- a/backend-demo/src/screenshot.rs
+++ b/backend-demo/src/screenshot.rs
@@ -4,7 +4,7 @@ use ashpd::{
         screenshot::{ColorOptions, ScreenshotImpl, ScreenshotOptions},
         Result,
     },
-    desktop::{screenshot::Screenshot as ScreenshotResponse, Color},
+    desktop::{screenshot::Screenshot as ScreenshotResponse, Color, HandleToken},
     AppID, WindowIdentifierType,
 };
 use async_trait::async_trait;
@@ -23,6 +23,7 @@ impl RequestImpl for Screenshot {
 impl ScreenshotImpl for Screenshot {
     async fn screenshot(
         &self,
+        _token: HandleToken,
         _app_id: Option<AppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: ScreenshotOptions,
@@ -34,6 +35,7 @@ impl ScreenshotImpl for Screenshot {
 
     async fn pick_color(
         &self,
+        _token: HandleToken,
         _app_id: Option<AppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: ColorOptions,

--- a/backend-demo/src/screenshot.rs
+++ b/backend-demo/src/screenshot.rs
@@ -14,8 +14,8 @@ pub struct Screenshot;
 
 #[async_trait]
 impl RequestImpl for Screenshot {
-    async fn close(&self) {
-        tracing::debug!("IN Close()");
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
     }
 }
 

--- a/backend-demo/src/secret.rs
+++ b/backend-demo/src/secret.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ashpd::{
     backend::{request::RequestImpl, secret::SecretImpl, Result},
+    desktop::HandleToken,
     zbus::zvariant::OwnedValue,
     AppID,
 };
@@ -21,6 +22,7 @@ impl RequestImpl for Secret {
 impl SecretImpl for Secret {
     async fn retrieve(
         &self,
+        _token: HandleToken,
         _app_id: AppID,
         _fd: std::os::fd::OwnedFd,
     ) -> Result<HashMap<String, OwnedValue>> {

--- a/backend-demo/src/secret.rs
+++ b/backend-demo/src/secret.rs
@@ -13,8 +13,8 @@ pub struct Secret;
 
 #[async_trait]
 impl RequestImpl for Secret {
-    async fn close(&self) {
-        tracing::debug!("IN Close()");
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
     }
 }
 

--- a/backend-demo/src/settings.rs
+++ b/backend-demo/src/settings.rs
@@ -5,7 +5,10 @@ use ashpd::{
         request::RequestImpl,
         settings::{SettingsImpl, SettingsSignalEmitter},
     },
-    desktop::settings::{ColorScheme, Namespace, APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY},
+    desktop::{
+        settings::{ColorScheme, Namespace, APPEARANCE_NAMESPACE, COLOR_SCHEME_KEY},
+        HandleToken,
+    },
     zbus::zvariant::OwnedValue,
     PortalError,
 };
@@ -20,8 +23,8 @@ pub struct Settings {
 
 #[async_trait]
 impl RequestImpl for Settings {
-    async fn close(&self) {
-        tracing::debug!("IN Close()");
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
     }
 }
 

--- a/backend-demo/src/wallpaper.rs
+++ b/backend-demo/src/wallpaper.rs
@@ -14,8 +14,8 @@ pub struct Wallpaper;
 
 #[async_trait]
 impl RequestImpl for Wallpaper {
-    async fn close(&self) {
-        tracing::debug!("IN Close()");
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
     }
 }
 

--- a/backend-demo/src/wallpaper.rs
+++ b/backend-demo/src/wallpaper.rs
@@ -4,6 +4,7 @@ use ashpd::{
         wallpaper::{WallpaperImpl, WallpaperOptions},
         Result,
     },
+    desktop::HandleToken,
     AppID, WindowIdentifierType,
 };
 use async_trait::async_trait;
@@ -22,6 +23,7 @@ impl RequestImpl for Wallpaper {
 impl WallpaperImpl for Wallpaper {
     async fn with_uri(
         &self,
+        _token: HandleToken,
         _app_id: Option<AppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _uri: url::Url,

--- a/src/backend/access.rs
+++ b/src/backend/access.rs
@@ -7,7 +7,7 @@ use crate::{
         request::{Request, RequestImpl},
         MaybeAppID, MaybeWindowIdentifier, Result,
     },
-    desktop::{file_chooser::Choice, request::Response, Icon},
+    desktop::{file_chooser::Choice, request::Response, HandleToken, Icon},
     zvariant::{self, DeserializeDict, OwnedObjectPath, SerializeDict},
     AppID, WindowIdentifierType,
 };
@@ -63,8 +63,10 @@ impl AccessResponse {
 
 #[async_trait]
 pub trait AccessImpl: RequestImpl {
+    #[allow(clippy::too_many_arguments)]
     async fn access_dialog(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: String,
@@ -109,10 +111,11 @@ impl AccessInterface {
         Request::spawn(
             "Access::AccessDialog",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
                 imp.access_dialog(
+                    HandleToken::try_from(&handle).unwrap(),
                     app_id.inner(),
                     window_identifier.inner(),
                     title,

--- a/src/backend/file_chooser.rs
+++ b/src/backend/file_chooser.rs
@@ -10,6 +10,7 @@ use crate::{
     desktop::{
         file_chooser::{Choice, FileFilter},
         request::Response,
+        HandleToken,
     },
     zvariant::{DeserializeDict, OwnedObjectPath, SerializeDict, Type},
     AppID, FilePath, WindowIdentifierType,
@@ -188,6 +189,7 @@ impl SaveFilesOptions {
 pub trait FileChooserImpl: RequestImpl {
     async fn open_file(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
@@ -196,6 +198,7 @@ pub trait FileChooserImpl: RequestImpl {
 
     async fn save_file(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
@@ -204,6 +207,7 @@ pub trait FileChooserImpl: RequestImpl {
 
     async fn save_files(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
@@ -243,11 +247,17 @@ impl FileChooserInterface {
         Request::spawn(
             "FileChooser::OpenFile",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
-                imp.open_file(app_id.inner(), window_identifier.inner(), &title, options)
-                    .await
+                imp.open_file(
+                    HandleToken::try_from(&handle).unwrap(),
+                    app_id.inner(),
+                    window_identifier.inner(),
+                    &title,
+                    options,
+                )
+                .await
             },
         )
         .await
@@ -267,11 +277,17 @@ impl FileChooserInterface {
         Request::spawn(
             "FileChooser::SaveFile",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
-                imp.save_file(app_id.inner(), window_identifier.inner(), &title, options)
-                    .await
+                imp.save_file(
+                    HandleToken::try_from(&handle).unwrap(),
+                    app_id.inner(),
+                    window_identifier.inner(),
+                    &title,
+                    options,
+                )
+                .await
             },
         )
         .await
@@ -291,11 +307,17 @@ impl FileChooserInterface {
         Request::spawn(
             "FileChooser::SaveFiles",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
-                imp.save_files(app_id.inner(), window_identifier.inner(), &title, options)
-                    .await
+                imp.save_files(
+                    HandleToken::try_from(&handle).unwrap(),
+                    app_id.inner(),
+                    window_identifier.inner(),
+                    &title,
+                    options,
+                )
+                .await
             },
         )
         .await

--- a/src/backend/print.rs
+++ b/src/backend/print.rs
@@ -10,6 +10,7 @@ use crate::{
     desktop::{
         print::{PageSetup, PreparePrint, Settings},
         request::Response,
+        HandleToken,
     },
     zvariant::{self, DeserializeDict, OwnedObjectPath},
     AppID, WindowIdentifierType,
@@ -51,8 +52,10 @@ impl PrintOptions {
 
 #[async_trait]
 pub trait PrintImpl: RequestImpl {
+    #[allow(clippy::too_many_arguments)]
     async fn prepare_print(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         parent_window: Option<WindowIdentifierType>,
         title: String,
@@ -63,6 +66,7 @@ pub trait PrintImpl: RequestImpl {
 
     async fn print(
         &self,
+        token: HandleToken,
         app_id: Option<AppID>,
         parent_window: Option<WindowIdentifierType>,
         title: String,
@@ -106,10 +110,11 @@ impl PrintInterface {
         Request::spawn(
             "Print::PreparePrint",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
                 imp.prepare_print(
+                    HandleToken::try_from(&handle).unwrap(),
                     app_id.inner(),
                     window_identifier.inner(),
                     title,
@@ -139,10 +144,11 @@ impl PrintInterface {
         Request::spawn(
             "Print::Print",
             &self.cnx,
-            handle,
+            handle.clone(),
             Arc::clone(&self.imp),
             async move {
                 imp.print(
+                    HandleToken::try_from(&handle).unwrap(),
                     app_id.inner(),
                     window_identifier.inner(),
                     title,

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,6 +1,9 @@
 mod handle_token;
 pub(crate) mod request;
 mod session;
+#[cfg(feature = "backend")]
+pub use self::handle_token::HandleToken;
+#[cfg(not(feature = "backend"))]
 pub(crate) use self::handle_token::HandleToken;
 pub use self::{
     request::{Request, Response, ResponseError, ResponseType},


### PR DESCRIPTION
In the current state of `ashpd::backend`, it is difficult to associate each request with the backend logic. So any further calls on the request is left in ambiguity.

For example, let's say two apps call `Account.GetUserInformation`. Our implementation shows dialogs that lets the user enter their details. Now, if one of these apps cancel their request with `Request.close()`, then it is impossible (or difficult) for implementer to know which dialog must be closed.

An easy fix to this problem is to pass the object path of request on the method calls. Now the backend can associate each request with its backend logic, like say a hash map of requests to dialogs. Then, when `close` method is called, it can identify which dialog to close and can close it.

I'm a Rust newbie, so not sure if `clone()`ing paths are a good idea or if we can tackle this problem from a different angle. :sweat_smile: 
Thank you