### PR TITLE
Fix links to source code in comments and documentation

### DIFF
--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -89,7 +89,7 @@ impl<'a> Camera<'a> {
     #[doc(alias = "xdp_portal_open_pipewire_remote_for_camera")]
     pub async fn open_pipe_wire_remote(&self) -> Result<OwnedFd, Error> {
         // `options` parameter doesn't seems to be used yet
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/camera.c#L178
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/camera.c#L273
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         let fd = self
             .0

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -333,7 +333,7 @@ impl<'a> RemoteDesktop<'a> {
         state: KeyState,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyKeyboardKeycode", &(session, options, keycode, state))
@@ -363,7 +363,7 @@ impl<'a> RemoteDesktop<'a> {
         state: KeyState,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyKeyboardKeysym", &(session, options, keysym, state))
@@ -391,7 +391,7 @@ impl<'a> RemoteDesktop<'a> {
         slot: u32,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyTouchUp", &(session, options, slot))
@@ -427,7 +427,7 @@ impl<'a> RemoteDesktop<'a> {
         y: f64,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyTouchDown", &(session, options, stream, slot, x, y))
@@ -463,7 +463,7 @@ impl<'a> RemoteDesktop<'a> {
         y: f64,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyTouchMotion", &(session, options, stream, slot, x, y))
@@ -494,7 +494,7 @@ impl<'a> RemoteDesktop<'a> {
         y: f64,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call(
@@ -526,7 +526,7 @@ impl<'a> RemoteDesktop<'a> {
         dy: f64,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyPointerMotion", &(session, options, dx, dy))
@@ -558,7 +558,7 @@ impl<'a> RemoteDesktop<'a> {
         state: KeyState,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call("NotifyPointerButton", &(session, options, button, state))
@@ -587,7 +587,7 @@ impl<'a> RemoteDesktop<'a> {
         steps: i32,
     ) -> Result<(), Error> {
         // The `notify` methods don't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L723
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L837-L838
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         self.0
             .call(
@@ -625,7 +625,7 @@ impl<'a> RemoteDesktop<'a> {
         dy: f64,
         finish: bool,
     ) -> Result<(), Error> {
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L911
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L1025-L1027
         let mut options: HashMap<&str, Value<'_>> = HashMap::new();
         options.insert("finish", Value::Bool(finish));
         self.0
@@ -655,7 +655,7 @@ impl<'a> RemoteDesktop<'a> {
     #[doc(alias = "ConnectToEIS")]
     pub async fn connect_to_eis(&self, session: &Session<'_, Self>) -> Result<OwnedFd, Error> {
         // `ConnectToEIS` doesn't take any options for now
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/remote-desktop.c#L1464
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/remote-desktop.c#L1457-L1458
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         let fd = self
             .0

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -305,7 +305,7 @@ impl<'a> Screencast<'a> {
         session: &Session<'_, impl HasScreencastSession>,
     ) -> Result<OwnedFd, Error> {
         // `options` parameter doesn't seems to be used yet
-        // see https://github.com/flatpak/xdg-desktop-portal/blob/master/src/screen-cast.c#L812
+        // see https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/screen-cast.c#L940
         let options: HashMap<&str, Value<'_>> = HashMap::new();
         let fd = self
             .0

--- a/src/documents/file_transfer.rs
+++ b/src/documents/file_transfer.rs
@@ -126,7 +126,7 @@ impl<'a> FileTransfer<'a> {
     #[doc(alias = "RetrieveFiles")]
     pub async fn retrieve_files(&self, key: &str) -> Result<Vec<String>, Error> {
         // `options` parameter doesn't seems to be used yet
-        // see https://github.com/GNOME/gtk/blob/master/gdk/filetransferportal.c#L284
+        // see https://github.com/GNOME/gtk/blob/4.16.12/gdk/filetransferportal.c#L288
         let options: HashMap<&str, Value<'_>> = HashMap::new();
 
         self.0.call("RetrieveFiles", &(key, options)).await

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use crate::desktop::{dynamic_launcher::UnexpectedIconError, request::ResponseErr
 
 /// An error type that describes the various DBus errors.
 ///
-/// See <https://github.com/flatpak/xdg-desktop-portal/blob/master/src/xdp-utils.h#L119-L127>.
+/// See <https://github.com/flatpak/xdg-desktop-portal/blob/1.20.0/src/xdp-utils.h#L88-L96>.
 #[allow(missing_docs)]
 #[derive(DBusError, Debug)]
 #[zbus(prefix = "org.freedesktop.portal.Error")]


### PR DESCRIPTION
Make them valid permalinks that will always point to the intended piece of code.