### PR TITLE
backend-demo: Implement the Access interface

### DIFF
--- a/backend-demo/data/ashpd-backend-demo.portal
+++ b/backend-demo/data/ashpd-backend-demo.portal
@@ -1,3 +1,3 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.ashpd-backend-demo
-Interfaces=org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Secret;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Wallpaper;
+Interfaces=org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Secret;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Wallpaper;

--- a/backend-demo/src/access.rs
+++ b/backend-demo/src/access.rs
@@ -1,0 +1,40 @@
+use ashpd::{
+    backend::{
+        access::{AccessImpl, AccessOptions, AccessResponse},
+        request::RequestImpl,
+        Result,
+    },
+    desktop::HandleToken,
+    AppID, WindowIdentifierType,
+};
+use async_trait::async_trait;
+
+#[derive(Default)]
+pub struct Access;
+
+#[async_trait]
+impl RequestImpl for Access {
+    async fn close(&self, token: HandleToken) {
+        tracing::debug!("IN Close(): {token}");
+    }
+}
+
+#[async_trait]
+impl AccessImpl for Access {
+    async fn access_dialog(
+        &self,
+        _handle: HandleToken,
+        _app_id: Option<AppID>,
+        _window_identifier: Option<WindowIdentifierType>,
+        _title: String,
+        _subtitle: String,
+        _body: String,
+        options: AccessOptions,
+    ) -> Result<AccessResponse> {
+        let mut response = AccessResponse::default();
+        for choice in options.choices() {
+            response = response.choice(choice.id(), choice.initial_selection());
+        }
+        Ok(response)
+    }
+}

--- a/backend-demo/src/main.rs
+++ b/backend-demo/src/main.rs
@@ -1,10 +1,12 @@
 use futures_util::future::pending;
+mod access;
 mod account;
 mod screenshot;
 mod secret;
 mod settings;
 mod wallpaper;
 
+use access::Access;
 use account::Account;
 use screenshot::Screenshot;
 use secret::Secret;
@@ -22,6 +24,7 @@ async fn main() -> ashpd::Result<()> {
     tracing_subscriber::fmt::init();
 
     ashpd::backend::Builder::new(NAME)?
+        .access(Access)
         .account(Account)
         .screenshot(Screenshot)
         .secret(Secret)


### PR DESCRIPTION
Without it, the xdg-desktop-portal frontend will skip looking for an
implementation of the Screenshot and Wallpaper interfaces, among others
(see https://github.com/flatpak/xdg-desktop-portal/blob/2fb76ffb/src/xdg-desktop-portal.c#L321-L358).