### PR TITLE
window_identifier: Add `set_parent_of` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "gio",
  "glib",
  "libc",
+ "x11",
 ]
 
 [[package]]
@@ -2173,6 +2174,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ enumflags2 = "0.7"
 futures-channel = "0.3"
 futures-util = "0.3"
 gdk4wayland = { package = "gdk4-wayland", version = "0.9", optional = true }
-gdk4x11 = { package = "gdk4-x11", version = "0.9", optional = true }
+gdk4x11 = { package = "gdk4-x11", version = "0.9", optional = true, features = [ "xlib" ] }
 glib = { version = "0.20", optional = true }
 gtk4 = { version = "0.9", optional = true }
 pipewire = { version = "0.8", optional = true }


### PR DESCRIPTION
This is commonly required in backend implementations as the portal dialog has to be set as modal with respect to the original application that launched them.

Not sure if I understand the macros control flow properly, any suggestions on improvement is very much welcome.