### PR TITLE
Allow passing a custom future spawner to backend builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.75"
 async-std = ["zbus/async-io", "dep:async-fs", "dep:async-net", "futures-util/io"]
 default = ["tokio"]
 
-backend = ["async-trait", "tokio"]
+backend = ["async-trait"]
 
 gtk4 = ["gtk4_x11", "gtk4_wayland"]
 gtk4_wayland = ["gdk4wayland", "glib", "dep:gtk4"]

--- a/backend-demo/Cargo.toml
+++ b/backend-demo/Cargo.toml
@@ -15,5 +15,5 @@ zbus = "5.0"
 
 [dependencies.ashpd]
 path = "../"
-features = ["backend", "tracing"]
+features = ["backend", "tracing", "tokio"]
 default-features = false

--- a/src/backend/access.rs
+++ b/src/backend/access.rs
@@ -78,12 +78,17 @@ pub trait AccessImpl: RequestImpl {
 
 pub(crate) struct AccessInterface {
     imp: Arc<dyn AccessImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl AccessInterface {
-    pub fn new(imp: Arc<dyn AccessImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn AccessImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -113,6 +118,7 @@ impl AccessInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.access_dialog(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/account.rs
+++ b/src/backend/account.rs
@@ -37,12 +37,17 @@ pub trait AccountImpl: RequestImpl {
 
 pub(crate) struct AccountInterface {
     imp: Arc<dyn AccountImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl AccountInterface {
-    pub fn new(imp: Arc<dyn AccountImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn AccountImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -69,6 +74,7 @@ impl AccountInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.get_user_information(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/app_chooser.rs
+++ b/src/backend/app_chooser.rs
@@ -129,12 +129,17 @@ pub trait AppChooserImpl: RequestImpl {
 
 pub(crate) struct AppChooserInterface {
     imp: Arc<dyn AppChooserImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl AppChooserInterface {
-    pub fn new(imp: Arc<dyn AppChooserImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn AppChooserImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -161,6 +166,7 @@ impl AppChooserInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.choose_application(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/builder.rs
+++ b/src/backend/builder.rs
@@ -171,10 +171,7 @@ impl Builder {
         cnx.request_name_with_flags(self.name, self.flags).await?;
 
         #[cfg(feature = "tokio")]
-        let spawn = {
-            println!("using tokio spawner");
-            self.spawn.unwrap_or(Arc::new(super::spawn::TokioSpawner))
-        };
+        let spawn = self.spawn.unwrap_or(Arc::new(super::spawn::TokioSpawner));
 
         #[cfg(not(feature = "tokio"))]
         let spawn = Arc::new(

--- a/src/backend/builder.rs
+++ b/src/backend/builder.rs
@@ -85,9 +85,9 @@ impl Builder {
     #[cfg(not(any(feature = "tokio")))]
     pub fn with_spawn(
         mut self,
-        imp: impl futures_util::task::Spawn + Send + Sync + 'static,
+        spawn: impl futures_util::task::Spawn + Send + Sync + 'static,
     ) -> Self {
-        self.spawn = Some(Arc::new(imp));
+        self.spawn = Some(Arc::new(spawn));
         self
     }
 
@@ -174,14 +174,13 @@ impl Builder {
         let spawn = self.spawn.unwrap_or(Arc::new(super::spawn::TokioSpawner));
 
         #[cfg(not(feature = "tokio"))]
-        let spawn = Arc::new(
-            self.spawn
-                .expect("Must provide a spawner when not using tokio"),
-        );
+        let spawn = self
+            .spawn
+            .expect("Must provide a spawner when not using tokio");
 
         let object_server = cnx.object_server();
         if let Some(imp) = self.account_impl {
-            let portal = AccountInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = AccountInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Account`");
             object_server
@@ -190,7 +189,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.access_impl {
-            let portal = AccessInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = AccessInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Access`");
             object_server
@@ -199,7 +198,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.app_chooser_impl {
-            let portal = AppChooserInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = AppChooserInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.AppChooser`");
             object_server
@@ -208,7 +207,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.background_impl {
-            let portal = BackgroundInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = BackgroundInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Background`");
             object_server
@@ -217,7 +216,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.email_impl {
-            let portal = EmailInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = EmailInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Email`");
             object_server
@@ -226,7 +225,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.file_chooser_impl {
-            let portal = FileChooserInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = FileChooserInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.FileChooser`");
             object_server
@@ -235,7 +234,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.lockdown_impl {
-            let portal = LockdownInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = LockdownInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Lockdown`");
             object_server
@@ -244,7 +243,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.permission_store_impl {
-            let portal = PermissionStoreInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = PermissionStoreInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.PermissionStore`");
             object_server
@@ -253,7 +252,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.print_impl {
-            let portal = PrintInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = PrintInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Print`");
             object_server
@@ -265,7 +264,7 @@ impl Builder {
             let portal = ScreencastInterface::new(
                 imp,
                 cnx.clone(),
-                spawn.clone(),
+                Arc::clone(&spawn),
                 Arc::clone(&self.sessions),
             );
             #[cfg(feature = "tracing")]
@@ -276,7 +275,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.screenshot_impl {
-            let portal = ScreenshotInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = ScreenshotInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Screenshot`");
             object_server
@@ -285,7 +284,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.secret_impl {
-            let portal = SecretInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = SecretInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Secret`");
             object_server
@@ -294,7 +293,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.settings_impl {
-            let portal = SettingsInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = SettingsInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Settings`");
             object_server
@@ -303,7 +302,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.wallpaper_impl {
-            let portal = WallpaperInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = WallpaperInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Wallpaper`");
             object_server
@@ -312,7 +311,7 @@ impl Builder {
         }
 
         if let Some(imp) = self.usb_impl {
-            let portal = UsbInterface::new(imp, cnx.clone(), spawn.clone());
+            let portal = UsbInterface::new(imp, cnx.clone(), Arc::clone(&spawn));
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Usb`");
             object_server

--- a/src/backend/email.rs
+++ b/src/backend/email.rs
@@ -72,12 +72,17 @@ pub trait EmailImpl: RequestImpl {
 
 pub(crate) struct EmailInterface {
     imp: Arc<dyn EmailImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl EmailInterface {
-    pub fn new(imp: Arc<dyn EmailImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn EmailImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -103,6 +108,7 @@ impl EmailInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.compose(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/file_chooser.rs
+++ b/src/backend/file_chooser.rs
@@ -217,12 +217,17 @@ pub trait FileChooserImpl: RequestImpl {
 
 pub(crate) struct FileChooserInterface {
     imp: Arc<dyn FileChooserImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl FileChooserInterface {
-    pub fn new(imp: Arc<dyn FileChooserImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn FileChooserImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -249,6 +254,7 @@ impl FileChooserInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.open_file(
                     HandleToken::try_from(&handle).unwrap(),
@@ -279,6 +285,7 @@ impl FileChooserInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.save_file(
                     HandleToken::try_from(&handle).unwrap(),
@@ -309,6 +316,7 @@ impl FileChooserInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.save_files(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/lockdown.rs
+++ b/src/backend/lockdown.rs
@@ -33,11 +33,17 @@ pub(crate) struct LockdownInterface {
     imp: Arc<dyn LockdownImpl>,
     #[allow(dead_code)]
     cnx: zbus::Connection,
+    #[allow(dead_code)]
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
 }
 
 impl LockdownInterface {
-    pub fn new(imp: Arc<dyn LockdownImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn LockdownImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -70,5 +70,6 @@ pub mod screenshot;
 pub mod secret;
 pub mod session;
 pub mod settings;
+mod spawn;
 pub mod usb;
 pub mod wallpaper;

--- a/src/backend/permission_store.rs
+++ b/src/backend/permission_store.rs
@@ -81,11 +81,17 @@ pub(crate) struct PermissionStoreInterface {
     imp: Arc<dyn PermissionStoreImpl>,
     #[allow(dead_code)]
     cnx: zbus::Connection,
+    #[allow(dead_code)]
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
 }
 
 impl PermissionStoreInterface {
-    pub fn new(imp: Arc<dyn PermissionStoreImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn PermissionStoreImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 
     pub async fn document_changed(

--- a/src/backend/print.rs
+++ b/src/backend/print.rs
@@ -77,12 +77,17 @@ pub trait PrintImpl: RequestImpl {
 
 pub(crate) struct PrintInterface {
     imp: Arc<dyn PrintImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl PrintInterface {
-    pub fn new(imp: Arc<dyn PrintImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn PrintImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -112,6 +117,7 @@ impl PrintInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.prepare_print(
                     HandleToken::try_from(&handle).unwrap(),
@@ -146,6 +152,7 @@ impl PrintInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.print(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -45,8 +45,6 @@ impl Request {
         let (fut, abort_handle) = abortable(callback);
         let token = HandleToken::try_from(&path).unwrap();
         let close_cb = move || {
-            let spawn = spawn.clone();
-
             // TODO: Should we log an error here with tracing, or just hard error? Tokio can't
             // error while spawning a future, but a custom executor might
             let _ = spawn.spawn(async move {

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -48,10 +48,9 @@ impl Request {
             if let Err(err) = spawn.spawn(async move {
                 RequestImpl::close(&*imp, token).await;
             }) {
-                let _ = err;
-
                 #[cfg(feature = "tracing")]
-                tracing::error!("Failed to spawn request closer");
+                tracing::error!("Failed to spawn request closer: {}", err);
+                let _ = err;
             }
         };
         let request = Request::new(close_cb, path.clone(), abort_handle, cnx.clone());

--- a/src/backend/screencast.rs
+++ b/src/backend/screencast.rs
@@ -106,7 +106,12 @@ impl ScreencastInterface {
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
         sessions: Arc<Mutex<SessionManager>>,
     ) -> Self {
-        Self { imp, cnx, spawn, sessions }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            sessions,
+        }
     }
 }
 

--- a/src/backend/screencast.rs
+++ b/src/backend/screencast.rs
@@ -94,6 +94,7 @@ pub trait ScreencastImpl: RequestImpl + SessionImpl {
 
 pub(crate) struct ScreencastInterface {
     imp: Arc<dyn ScreencastImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
     sessions: Arc<Mutex<SessionManager>>,
 }
@@ -102,9 +103,10 @@ impl ScreencastInterface {
     pub fn new(
         imp: Arc<dyn ScreencastImpl>,
         cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
         sessions: Arc<Mutex<SessionManager>>,
     ) -> Self {
-        Self { imp, cnx, sessions }
+        Self { imp, cnx, spawn, sessions }
     }
 }
 
@@ -160,6 +162,7 @@ impl ScreencastInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.create_session(
                     HandleToken::try_from(&handle).unwrap(),
@@ -215,6 +218,7 @@ impl ScreencastInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.select_sources(session_token, app_id.inner(), options)
                     .await
@@ -245,6 +249,7 @@ impl ScreencastInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.start_cast(
                     session_token,

--- a/src/backend/screenshot.rs
+++ b/src/backend/screenshot.rs
@@ -61,12 +61,17 @@ pub trait ScreenshotImpl: RequestImpl {
 
 pub(crate) struct ScreenshotInterface {
     imp: Arc<dyn ScreenshotImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl ScreenshotInterface {
-    pub fn new(imp: Arc<dyn ScreenshotImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn ScreenshotImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -93,6 +98,7 @@ impl ScreenshotInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.screenshot(
                     HandleToken::try_from(&handle).unwrap(),
@@ -122,6 +128,7 @@ impl ScreenshotInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.pick_color(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/secret.rs
+++ b/src/backend/secret.rs
@@ -24,12 +24,17 @@ pub trait SecretImpl: RequestImpl {
 
 pub(crate) struct SecretInterface {
     imp: Arc<dyn SecretImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl SecretInterface {
-    pub fn new(imp: Arc<dyn SecretImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn SecretImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -55,6 +60,7 @@ impl SecretInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.retrieve(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/settings.rs
+++ b/src/backend/settings.rs
@@ -39,11 +39,17 @@ pub trait SettingsImpl: Send + Sync {
 pub(crate) struct SettingsInterface {
     imp: Arc<dyn SettingsImpl>,
     cnx: zbus::Connection,
+    #[allow(dead_code)]
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
 }
 
 impl SettingsInterface {
-    pub fn new(imp: Arc<dyn SettingsImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn SettingsImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 
     pub async fn changed(&self, namespace: &str, key: &str, value: Value<'_>) -> zbus::Result<()> {

--- a/src/backend/spawn.rs
+++ b/src/backend/spawn.rs
@@ -1,0 +1,13 @@
+#[cfg(feature = "tokio")]
+pub struct TokioSpawner;
+
+#[cfg(feature = "tokio")]
+impl futures_util::task::Spawn for TokioSpawner {
+    fn spawn_obj(
+        &self,
+        future: futures_util::task::FutureObj<'static, ()>,
+    ) -> std::result::Result<(), futures_util::task::SpawnError> {
+        tokio::spawn(future);
+        Ok(())
+    }
+}

--- a/src/backend/usb.rs
+++ b/src/backend/usb.rs
@@ -48,12 +48,17 @@ pub trait UsbImpl: RequestImpl {
 
 pub(crate) struct UsbInterface {
     imp: Arc<dyn UsbImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl UsbInterface {
-    pub fn new(imp: Arc<dyn UsbImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn UsbImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -81,6 +86,7 @@ impl UsbInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.acquire_devices(
                     HandleToken::try_from(&handle).unwrap(),

--- a/src/backend/wallpaper.rs
+++ b/src/backend/wallpaper.rs
@@ -45,12 +45,17 @@ pub trait WallpaperImpl: RequestImpl {
 
 pub(crate) struct WallpaperInterface {
     imp: Arc<dyn WallpaperImpl>,
+    spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
 }
 
 impl WallpaperInterface {
-    pub fn new(imp: Arc<dyn WallpaperImpl>, cnx: zbus::Connection) -> Self {
-        Self { imp, cnx }
+    pub fn new(
+        imp: Arc<dyn WallpaperImpl>,
+        cnx: zbus::Connection,
+        spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    ) -> Self {
+        Self { imp, cnx, spawn }
     }
 }
 
@@ -78,6 +83,7 @@ impl WallpaperInterface {
             &self.cnx,
             handle.clone(),
             Arc::clone(&self.imp),
+            Arc::clone(&self.spawn),
             async move {
                 imp.with_uri(
                     HandleToken::try_from(&handle).unwrap(),


### PR DESCRIPTION
Closes #278.

I've tested this using both tokio and a custom executor (gpui).

I'm not super happy with this, as it potentially introduces a bit of runtime overhead since the executor now has to be passed around and cloned. It would be possible to add feature flags to every place it's used and avoid that, but that adds a lot of noise to a lot of places - I'd be happy to do that though, if you're fine with that.

That way, it would also be possible to make the executor a required parameter on the builder, right now it errors at runtime when building the backend if you didn't pass a spawner and have `tokio` disabled.