### PR TITLE
Add set_session_connection function for custom zbus connections

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod file_path;
 pub use self::file_path::FilePath;
 
 mod proxy;
+pub use proxy::set_session_connection;
 
 #[cfg(feature = "backend")]
 #[cfg_attr(docsrs, doc(cfg(feature = "backend")))]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -26,6 +26,17 @@ pub(crate) const FLATPAK_DEVELOPMENT_PATH: &str = "/org/freedesktop/Flatpak/Deve
 
 static SESSION: OnceLock<zbus::Connection> = OnceLock::new();
 
+/// Set a custom zbus connection to be used for all desktop portal operations.
+/// 
+/// This must be called before any other desktop portal functions are used.
+/// If not called, a default session bus connection will be created automatically.
+/// 
+/// Returns `Ok(())` if the connection was set successfully, or `Err(connection)` 
+/// if a connection was already set.
+pub fn set_session_connection(connection: zbus::Connection) -> Result<(), zbus::Connection> {
+    SESSION.set(connection)
+}
+
 #[derive(Debug)]
 pub struct Proxy<'a> {
     inner: zbus::Proxy<'a>,


### PR DESCRIPTION
I'm making a UI toolkit that establishes its own connection through zbus so I want to simplify it and use the connection I already have, idk if this is the best way to do that but I figured it fit most in line with what you had already...