### PR TITLE
Remove unnecessary lifetime parameters on proxy types

### DIFF
--- a/src/desktop/account.rs
+++ b/src/desktop/account.rs
@@ -82,10 +82,10 @@ impl UserInformation {
     }
 }
 
-struct AccountProxy<'a>(Proxy<'a>);
+struct AccountProxy(Proxy<'static>);
 
-impl<'a> AccountProxy<'a> {
-    pub async fn new() -> Result<AccountProxy<'a>, Error> {
+impl AccountProxy {
+    pub async fn new() -> Result<AccountProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Account").await?;
         Ok(Self(proxy))
     }
@@ -107,8 +107,8 @@ impl<'a> AccountProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for AccountProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for AccountProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/background.rs
+++ b/src/desktop/background.rs
@@ -88,11 +88,11 @@ struct SetStatusOptions {
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Background`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Background.html).
 #[doc(alias = "org.freedesktop.portal.Background")]
-pub struct BackgroundProxy<'a>(Proxy<'a>);
+pub struct BackgroundProxy(Proxy<'static>);
 
-impl<'a> BackgroundProxy<'a> {
+impl BackgroundProxy {
     /// Create a new instance of [`BackgroundProxy`].
-    pub async fn new() -> Result<BackgroundProxy<'a>, Error> {
+    pub async fn new() -> Result<BackgroundProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Background").await?;
         Ok(Self(proxy))
     }
@@ -142,8 +142,8 @@ impl<'a> BackgroundProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for BackgroundProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for BackgroundProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/camera.rs
+++ b/src/desktop/camera.rs
@@ -50,11 +50,11 @@ struct CameraAccessOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Camera`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Camera.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Camera")]
-pub struct Camera<'a>(Proxy<'a>);
+pub struct Camera(Proxy<'static>);
 
-impl<'a> Camera<'a> {
+impl Camera {
     /// Create a new instance of [`Camera`].
-    pub async fn new() -> Result<Camera<'a>, Error> {
+    pub async fn new() -> Result<Camera, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Camera").await?;
         Ok(Self(proxy))
     }
@@ -108,8 +108,8 @@ impl<'a> Camera<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Camera<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Camera {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/clipboard.rs
+++ b/src/desktop/clipboard.rs
@@ -39,11 +39,11 @@ impl SelectionOwnerChanged {
 
 #[doc(alias = "org.freedesktop.portal.Clipboard")]
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Clipboard`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html).
-pub struct Clipboard<'a>(Proxy<'a>);
+pub struct Clipboard(Proxy<'static>);
 
-impl<'a> Clipboard<'a> {
+impl Clipboard {
     /// Create a new instance of [`Clipboard`].
-    pub async fn new() -> Result<Clipboard<'a>> {
+    pub async fn new() -> Result<Clipboard> {
         Ok(Self(
             Proxy::new_desktop("org.freedesktop.portal.Clipboard").await?,
         ))
@@ -53,7 +53,7 @@ impl<'a> Clipboard<'a> {
     ///
     /// See also [`RequestClipboard`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-requestclipboard).
     #[doc(alias = "RequestClipboard")]
-    pub async fn request(&self, session: &Session<'_, RemoteDesktop<'_>>) -> Result<()> {
+    pub async fn request(&self, session: &Session<'_, RemoteDesktop>) -> Result<()> {
         let options: HashMap<&str, Value<'_>> = HashMap::default();
         self.0
             .call_method("RequestClipboard", &(session, options))
@@ -67,7 +67,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SetSelection")]
     pub async fn set_selection(
         &self,
-        session: &Session<'_, RemoteDesktop<'_>>,
+        session: &Session<'_, RemoteDesktop>,
         mime_types: &[&str],
     ) -> Result<()> {
         let options = SetSelectionOptions { mime_types };
@@ -84,7 +84,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SelectionWrite")]
     pub async fn selection_write(
         &self,
-        session: &Session<'_, RemoteDesktop<'_>>,
+        session: &Session<'_, RemoteDesktop>,
         serial: u32,
     ) -> Result<OwnedFd> {
         let fd = self
@@ -100,7 +100,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SelectionWriteDone")]
     pub async fn selection_write_done(
         &self,
-        session: &Session<'_, RemoteDesktop<'_>>,
+        session: &Session<'_, RemoteDesktop>,
         serial: u32,
         success: bool,
     ) -> Result<()> {
@@ -115,7 +115,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SelectionRead")]
     pub async fn selection_read(
         &self,
-        session: &Session<'_, RemoteDesktop<'_>>,
+        session: &Session<'_, RemoteDesktop>,
         mime_type: &str,
     ) -> Result<OwnedFd> {
         let fd = self
@@ -132,7 +132,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SelectionOwnerChanged")]
     pub async fn receive_selection_owner_changed(
         &self,
-    ) -> Result<impl Stream<Item = (Session<'_, RemoteDesktop<'_>>, SelectionOwnerChanged)>> {
+    ) -> Result<impl Stream<Item = (Session<'_, RemoteDesktop>, SelectionOwnerChanged)>> {
         Ok(self
             .0
             .signal::<(OwnedObjectPath, SelectionOwnerChanged)>("SelectionOwnerChanged")
@@ -146,7 +146,7 @@ impl<'a> Clipboard<'a> {
     #[doc(alias = "SelectionTransfer")]
     pub async fn receive_selection_transfer(
         &self,
-    ) -> Result<impl Stream<Item = (Session<'_, RemoteDesktop<'_>>, String, u32)>> {
+    ) -> Result<impl Stream<Item = (Session<'_, RemoteDesktop>, String, u32)>> {
         Ok(self
             .0
             .signal::<(OwnedObjectPath, String, u32)>("SelectionTransfer")
@@ -160,8 +160,8 @@ impl<'a> Clipboard<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Clipboard<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Clipboard {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/device.rs
+++ b/src/desktop/device.rs
@@ -100,11 +100,11 @@ impl FromStr for Device {
 /// [`org.freedesktop.portal.Device`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Device.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Device")]
-pub struct DeviceProxy<'a>(Proxy<'a>);
+pub struct DeviceProxy(Proxy<'static>);
 
-impl<'a> DeviceProxy<'a> {
+impl DeviceProxy {
     /// Create a new instance of [`DeviceProxy`].
-    pub async fn new() -> Result<DeviceProxy<'a>, Error> {
+    pub async fn new() -> Result<DeviceProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Device").await?;
         Ok(Self(proxy))
     }
@@ -136,8 +136,8 @@ impl<'a> DeviceProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for DeviceProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for DeviceProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/dynamic_launcher.rs
+++ b/src/desktop/dynamic_launcher.rs
@@ -233,11 +233,11 @@ impl std::fmt::Display for UnexpectedIconError {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.DynamicLauncher`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.DynamicLauncher.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.DynamicLauncher")]
-pub struct DynamicLauncherProxy<'a>(Proxy<'a>);
+pub struct DynamicLauncherProxy(Proxy<'static>);
 
-impl<'a> DynamicLauncherProxy<'a> {
+impl DynamicLauncherProxy {
     /// Create a new instance of [`DynamicLauncherProxy`].
-    pub async fn new() -> Result<DynamicLauncherProxy<'a>, Error> {
+    pub async fn new() -> Result<DynamicLauncherProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.DynamicLauncher").await?;
         Ok(Self(proxy))
     }
@@ -358,8 +358,8 @@ impl<'a> DynamicLauncherProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for DynamicLauncherProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for DynamicLauncherProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/email.rs
+++ b/src/desktop/email.rs
@@ -51,11 +51,11 @@ struct EmailOptions {
 
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Email")]
-struct EmailProxy<'a>(Proxy<'a>);
+struct EmailProxy(Proxy<'static>);
 
-impl<'a> EmailProxy<'a> {
+impl EmailProxy {
     /// Create a new instance of [`EmailProxy`].
-    pub async fn new() -> Result<EmailProxy<'a>, Error> {
+    pub async fn new() -> Result<EmailProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Email").await?;
         Ok(Self(proxy))
     }
@@ -90,8 +90,8 @@ impl<'a> EmailProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for EmailProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for EmailProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/file_chooser.rs
+++ b/src/desktop/file_chooser.rs
@@ -301,11 +301,11 @@ impl SelectedFiles {
 }
 
 #[doc(alias = "org.freedesktop.portal.FileChooser")]
-struct FileChooserProxy<'a>(Proxy<'a>);
+struct FileChooserProxy(Proxy<'static>);
 
-impl<'a> FileChooserProxy<'a> {
+impl FileChooserProxy {
     /// Create a new instance of [`FileChooserProxy`].
-    pub async fn new() -> Result<FileChooserProxy<'a>, Error> {
+    pub async fn new() -> Result<FileChooserProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.FileChooser").await?;
         Ok(Self(proxy))
     }
@@ -362,8 +362,8 @@ impl<'a> FileChooserProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for FileChooserProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for FileChooserProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/game_mode.rs
+++ b/src/desktop/game_mode.rs
@@ -74,11 +74,11 @@ enum RegisterStatus {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.GameMode`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GameMode.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.GameMode")]
-pub struct GameMode<'a>(Proxy<'a>);
+pub struct GameMode(Proxy<'static>);
 
-impl<'a> GameMode<'a> {
+impl GameMode {
     /// Create a new instance of [`GameMode`].
-    pub async fn new() -> Result<GameMode<'a>, Error> {
+    pub async fn new() -> Result<GameMode, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.GameMode").await?;
         Ok(Self(proxy))
     }
@@ -314,8 +314,8 @@ impl<'a> GameMode<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for GameMode<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for GameMode {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/global_shortcuts.rs
+++ b/src/desktop/global_shortcuts.rs
@@ -218,11 +218,11 @@ impl ShortcutsChanged {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.GlobalShortcuts`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.GlobalShortcuts")]
-pub struct GlobalShortcuts<'a>(Proxy<'a>);
+pub struct GlobalShortcuts(Proxy<'static>);
 
-impl<'a> GlobalShortcuts<'a> {
+impl GlobalShortcuts {
     /// Create a new instance of [`GlobalShortcuts`].
-    pub async fn new() -> Result<GlobalShortcuts<'a>, Error> {
+    pub async fn new() -> Result<GlobalShortcuts, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.GlobalShortcuts").await?;
         Ok(Self(proxy))
     }
@@ -233,7 +233,7 @@ impl<'a> GlobalShortcuts<'a> {
     ///
     /// See also [`CreateSession`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html#org-freedesktop-portal-globalshortcuts-createsession).
     #[doc(alias = "CreateSession")]
-    pub async fn create_session(&self) -> Result<Session<'a, Self>, Error> {
+    pub async fn create_session(&self) -> Result<Session<'static, Self>, Error> {
         let options = CreateSessionOptions::default();
         let (request, proxy) = futures_util::try_join!(
             self.0
@@ -341,13 +341,13 @@ impl<'a> GlobalShortcuts<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for GlobalShortcuts<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for GlobalShortcuts {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl crate::Sealed for GlobalShortcuts<'_> {}
-impl SessionPortal for GlobalShortcuts<'_> {}
+impl crate::Sealed for GlobalShortcuts {}
+impl SessionPortal for GlobalShortcuts {}

--- a/src/desktop/inhibit.rs
+++ b/src/desktop/inhibit.rs
@@ -140,11 +140,11 @@ pub enum SessionState {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Inhibit`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Inhibit.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Inhibit")]
-pub struct InhibitProxy<'a>(Proxy<'a>);
+pub struct InhibitProxy(Proxy<'static>);
 
-impl<'a> InhibitProxy<'a> {
+impl InhibitProxy {
     /// Create a new instance of [`InhibitProxy`].
-    pub async fn new() -> Result<InhibitProxy<'a>, Error> {
+    pub async fn new() -> Result<InhibitProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Inhibit").await?;
         Ok(Self(proxy))
     }
@@ -165,7 +165,7 @@ impl<'a> InhibitProxy<'a> {
     pub async fn create_monitor(
         &self,
         identifier: Option<&WindowIdentifier>,
-    ) -> Result<Session<'a, Self>, Error> {
+    ) -> Result<Session<'static, Self>, Error> {
         let options = CreateMonitorOptions::default();
         let identifier = identifier.to_string_or_empty();
         let body = &(&identifier, &options);
@@ -243,13 +243,13 @@ impl<'a> InhibitProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for InhibitProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for InhibitProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl crate::Sealed for InhibitProxy<'_> {}
-impl SessionPortal for InhibitProxy<'_> {}
+impl crate::Sealed for InhibitProxy {}
+impl SessionPortal for InhibitProxy {}

--- a/src/desktop/input_capture.rs
+++ b/src/desktop/input_capture.rs
@@ -560,11 +560,11 @@ impl SetPointerBarriersResponse {
 
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.InputCapture`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.InputCapture.html).
 #[doc(alias = "org.freedesktop.portal.InputCapture")]
-pub struct InputCapture<'a>(Proxy<'a>);
+pub struct InputCapture(Proxy<'static>);
 
-impl<'a> InputCapture<'a> {
+impl InputCapture {
     /// Create a new instance of [`InputCapture`].
-    pub async fn new() -> Result<InputCapture<'a>, Error> {
+    pub async fn new() -> Result<InputCapture, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.InputCapture").await?;
         Ok(Self(proxy))
     }
@@ -579,7 +579,7 @@ impl<'a> InputCapture<'a> {
         &self,
         identifier: Option<&WindowIdentifier>,
         capabilities: BitFlags<Capabilities>,
-    ) -> Result<(Session<'_, Self>, BitFlags<Capabilities>), Error> {
+    ) -> Result<(Session<'static, Self>, BitFlags<Capabilities>), Error> {
         let options = CreateSessionOptions {
             handle_token: Default::default(),
             session_handle_token: Default::default(),
@@ -747,13 +747,13 @@ impl<'a> InputCapture<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for InputCapture<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for InputCapture {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl crate::Sealed for InputCapture<'_> {}
-impl SessionPortal for InputCapture<'_> {}
+impl crate::Sealed for InputCapture {}
+impl SessionPortal for InputCapture {}

--- a/src/desktop/memory_monitor.rs
+++ b/src/desktop/memory_monitor.rs
@@ -30,11 +30,11 @@ use crate::{proxy::Proxy, Error};
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.MemoryMonitor`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.MemoryMonitor.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.MemoryMonitor")]
-pub struct MemoryMonitor<'a>(Proxy<'a>);
+pub struct MemoryMonitor(Proxy<'static>);
 
-impl<'a> MemoryMonitor<'a> {
+impl MemoryMonitor {
     /// Create a new instance of [`MemoryMonitor`].
-    pub async fn new() -> Result<MemoryMonitor<'a>, Error> {
+    pub async fn new() -> Result<MemoryMonitor, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.MemoryMonitor").await?;
         Ok(Self(proxy))
     }
@@ -52,8 +52,8 @@ impl<'a> MemoryMonitor<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for MemoryMonitor<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for MemoryMonitor {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/network_monitor.rs
+++ b/src/desktop/network_monitor.rs
@@ -91,11 +91,11 @@ impl fmt::Display for Connectivity {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.NetworkMonitor`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.NetworkMonitor.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.NetworkMonitor")]
-pub struct NetworkMonitor<'a>(Proxy<'a>);
+pub struct NetworkMonitor(Proxy<'static>);
 
-impl<'a> NetworkMonitor<'a> {
+impl NetworkMonitor {
     /// Create a new instance of [`NetworkMonitor`].
-    pub async fn new() -> Result<NetworkMonitor<'a>, Error> {
+    pub async fn new() -> Result<NetworkMonitor, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.NetworkMonitor").await?;
         Ok(Self(proxy))
     }
@@ -201,8 +201,8 @@ impl<'a> NetworkMonitor<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for NetworkMonitor<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for NetworkMonitor {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/notification.rs
+++ b/src/desktop/notification.rs
@@ -580,11 +580,11 @@ struct SupportedOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Notification`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Notification.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Notification")]
-pub struct NotificationProxy<'a>(Proxy<'a>);
+pub struct NotificationProxy(Proxy<'static>);
 
-impl<'a> NotificationProxy<'a> {
+impl NotificationProxy {
     /// Create a new instance of [`NotificationProxy`].
-    pub async fn new() -> Result<NotificationProxy<'a>, Error> {
+    pub async fn new() -> Result<NotificationProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Notification").await?;
         Ok(Self(proxy))
     }
@@ -669,8 +669,8 @@ impl<'a> NotificationProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for NotificationProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for NotificationProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/open_uri.rs
+++ b/src/desktop/open_uri.rs
@@ -95,11 +95,11 @@ pub struct SchemeSupportedOptions {}
 ///
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.OpenURI`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.OpenURI.html).
 #[derive(Debug)]
-pub struct OpenURIProxy<'a>(Proxy<'a>);
+pub struct OpenURIProxy(Proxy<'static>);
 
-impl<'a> OpenURIProxy<'a> {
+impl OpenURIProxy {
     /// Create a new instance of [`OpenURIProxy`].
-    pub async fn new() -> Result<OpenURIProxy<'a>, Error> {
+    pub async fn new() -> Result<OpenURIProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.OpenURI").await?;
         Ok(Self(proxy))
     }
@@ -211,8 +211,8 @@ impl<'a> OpenURIProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for OpenURIProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for OpenURIProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/power_profile_monitor.rs
+++ b/src/desktop/power_profile_monitor.rs
@@ -12,11 +12,11 @@ use crate::{proxy::Proxy, Error};
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.PowerProfileMonitor`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.PowerProfileMonitor.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.PowerProfileMonitor")]
-pub struct PowerProfileMonitor<'a>(Proxy<'a>);
+pub struct PowerProfileMonitor(Proxy<'static>);
 
-impl<'a> PowerProfileMonitor<'a> {
+impl PowerProfileMonitor {
     /// Create a new instance of [`PowerProfileMonitor`].
-    pub async fn new() -> Result<PowerProfileMonitor<'a>, Error> {
+    pub async fn new() -> Result<PowerProfileMonitor, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.PowerProfileMonitor").await?;
         Ok(Self(proxy))
     }
@@ -32,8 +32,8 @@ impl<'a> PowerProfileMonitor<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for PowerProfileMonitor<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for PowerProfileMonitor {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/print.rs
+++ b/src/desktop/print.rs
@@ -649,11 +649,11 @@ pub struct PreparePrint {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Print`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Print.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Print")]
-pub struct PrintProxy<'a>(Proxy<'a>);
+pub struct PrintProxy(Proxy<'static>);
 
-impl<'a> PrintProxy<'a> {
+impl PrintProxy {
     /// Create a new instance of [`PrintProxy`].
-    pub async fn new() -> Result<PrintProxy<'a>, Error> {
+    pub async fn new() -> Result<PrintProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Print").await?;
         Ok(Self(proxy))
     }
@@ -677,7 +677,7 @@ impl<'a> PrintProxy<'a> {
     /// See also [`PreparePrint`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Print.html#org-freedesktop-portal-print-prepareprint).
     #[doc(alias = "PreparePrint")]
     #[doc(alias = "xdp_portal_prepare_print")]
-    pub async fn prepare_print(
+    pub async fn prepare_print<'a>(
         &self,
         identifier: Option<&WindowIdentifier>,
         title: &str,
@@ -741,8 +741,8 @@ impl<'a> PrintProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for PrintProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for PrintProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/proxy_resolver.rs
+++ b/src/desktop/proxy_resolver.rs
@@ -25,11 +25,11 @@ use crate::{proxy::Proxy, Error};
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.ProxyResolver`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ProxyResolver.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.ProxyResolver")]
-pub struct ProxyResolver<'a>(Proxy<'a>);
+pub struct ProxyResolver(Proxy<'static>);
 
-impl<'a> ProxyResolver<'a> {
+impl ProxyResolver {
     /// Create a new instance of [`ProxyResolver`].
-    pub async fn new() -> Result<ProxyResolver<'a>, Error> {
+    pub async fn new() -> Result<ProxyResolver, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.ProxyResolver").await?;
         Ok(Self(proxy))
     }
@@ -51,8 +51,8 @@ impl<'a> ProxyResolver<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for ProxyResolver<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for ProxyResolver {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/realtime.rs
+++ b/src/desktop/realtime.rs
@@ -9,11 +9,11 @@ use crate::{proxy::Proxy, Error, Pid};
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Realtime`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Realtime.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Realtime")]
-pub struct Realtime<'a>(Proxy<'a>);
+pub struct Realtime(Proxy<'static>);
 
-impl<'a> Realtime<'a> {
+impl Realtime {
     /// Create a new instance of [`Realtime`].
-    pub async fn new() -> Result<Realtime<'a>, Error> {
+    pub async fn new() -> Result<Realtime, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Realtime").await?;
         Ok(Self(proxy))
     }
@@ -69,8 +69,8 @@ impl<'a> Realtime<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Realtime<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Realtime {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/remote_desktop.rs
+++ b/src/desktop/remote_desktop.rs
@@ -223,11 +223,11 @@ impl SelectedDevices {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.RemoteDesktop`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.RemoteDesktop")]
-pub struct RemoteDesktop<'a>(Proxy<'a>);
+pub struct RemoteDesktop(Proxy<'static>);
 
-impl<'a> RemoteDesktop<'a> {
+impl RemoteDesktop {
     /// Create a new instance of [`RemoteDesktop`].
-    pub async fn new() -> Result<RemoteDesktop<'a>, Error> {
+    pub async fn new() -> Result<RemoteDesktop, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.RemoteDesktop").await?;
         Ok(Self(proxy))
     }
@@ -241,7 +241,7 @@ impl<'a> RemoteDesktop<'a> {
     /// See also [`CreateSession`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html#org-freedesktop-portal-remotedesktop-createsession).
     #[doc(alias = "CreateSession")]
     #[doc(alias = "xdp_portal_create_remote_desktop_session")]
-    pub async fn create_session(&self) -> Result<Session<'a, Self>, Error> {
+    pub async fn create_session(&self) -> Result<Session<'static, Self>, Error> {
         let options = CreateRemoteOptions::default();
         let (request, proxy) = futures_util::try_join!(
             self.0
@@ -678,13 +678,13 @@ impl<'a> RemoteDesktop<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for RemoteDesktop<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for RemoteDesktop {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl crate::Sealed for RemoteDesktop<'_> {}
-impl SessionPortal for RemoteDesktop<'_> {}
+impl crate::Sealed for RemoteDesktop {}
+impl SessionPortal for RemoteDesktop {}

--- a/src/desktop/screencast.rs
+++ b/src/desktop/screencast.rs
@@ -360,11 +360,11 @@ impl StreamBuilder {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.ScreenCast`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.ScreenCast")]
-pub struct Screencast<'a>(Proxy<'a>);
+pub struct Screencast(Proxy<'static>);
 
-impl<'a> Screencast<'a> {
+impl Screencast {
     /// Create a new instance of [`Screencast`].
-    pub async fn new() -> Result<Screencast<'a>, Error> {
+    pub async fn new() -> Result<Screencast, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.ScreenCast").await?;
         Ok(Self(proxy))
     }
@@ -376,7 +376,7 @@ impl<'a> Screencast<'a> {
     /// See also [`CreateSession`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html#org-freedesktop-portal-screencast-createsession).
     #[doc(alias = "CreateSession")]
     #[doc(alias = "xdp_portal_create_screencast_session")]
-    pub async fn create_session(&self) -> Result<Session<'a, Self>, Error> {
+    pub async fn create_session(&self) -> Result<Session<'static, Self>, Error> {
         let options = CreateSessionOptions::default();
         let (request, proxy) = futures_util::try_join!(
             self.0
@@ -516,18 +516,18 @@ impl<'a> Screencast<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Screencast<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Screencast {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl crate::Sealed for Screencast<'_> {}
-impl SessionPortal for Screencast<'_> {}
+impl crate::Sealed for Screencast {}
+impl SessionPortal for Screencast {}
 
 /// Defines which portals session can be used in a screen-cast.
 pub trait HasScreencastSession: SessionPortal {}
-impl HasScreencastSession for Screencast<'_> {}
-impl HasScreencastSession for RemoteDesktop<'_> {}
+impl HasScreencastSession for Screencast {}
+impl HasScreencastSession for RemoteDesktop {}

--- a/src/desktop/screenshot.rs
+++ b/src/desktop/screenshot.rs
@@ -94,11 +94,11 @@ struct ColorOptions {
 
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Screenshot")]
-struct ScreenshotProxy<'a>(Proxy<'a>);
+struct ScreenshotProxy(Proxy<'static>);
 
-impl<'a> ScreenshotProxy<'a> {
+impl ScreenshotProxy {
     /// Create a new instance of [`ScreenshotProxy`].
-    pub async fn new() -> Result<ScreenshotProxy<'a>, Error> {
+    pub async fn new() -> Result<ScreenshotProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Screenshot").await?;
         Ok(Self(proxy))
     }
@@ -159,8 +159,8 @@ impl<'a> ScreenshotProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for ScreenshotProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for ScreenshotProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/secret.rs
+++ b/src/desktop/secret.rs
@@ -49,11 +49,11 @@ struct RetrieveOptions {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Secret`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Secret")]
-pub struct Secret<'a>(Proxy<'a>);
+pub struct Secret(Proxy<'static>);
 
-impl<'a> Secret<'a> {
+impl Secret {
     /// Create a new instance of [`Secret`].
-    pub async fn new() -> Result<Secret<'a>, Error> {
+    pub async fn new() -> Result<Secret, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Secret").await?;
         Ok(Self(proxy))
     }
@@ -80,8 +80,8 @@ impl<'a> Secret<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Secret<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Secret {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/settings.rs
+++ b/src/desktop/settings.rs
@@ -171,11 +171,11 @@ pub const CONTRAST_KEY: &str = "contrast";
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Settings`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Settings")]
-pub struct Settings<'a>(Proxy<'a>);
+pub struct Settings(Proxy<'static>);
 
-impl<'a> Settings<'a> {
+impl Settings {
     /// Create a new instance of [`Settings`].
-    pub async fn new() -> Result<Settings<'a>, Error> {
+    pub async fn new() -> Result<Settings, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Settings").await?;
         Ok(Self(proxy))
     }
@@ -333,8 +333,8 @@ impl<'a> Settings<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Settings<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for Settings {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/trash.rs
+++ b/src/desktop/trash.rs
@@ -49,11 +49,11 @@ enum TrashStatus {
 /// Wrapper of the DBus interface: [`org.freedesktop.portal.Trash`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Trash.html).
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Trash")]
-pub struct TrashProxy<'a>(Proxy<'a>);
+pub struct TrashProxy(Proxy<'static>);
 
-impl<'a> TrashProxy<'a> {
+impl TrashProxy {
     /// Create a new instance of [`TrashProxy`].
-    pub async fn new() -> Result<TrashProxy<'a>, Error> {
+    pub async fn new() -> Result<TrashProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Trash").await?;
         Ok(Self(proxy))
     }
@@ -82,8 +82,8 @@ impl<'a> TrashProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for TrashProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for TrashProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/desktop/usb.rs
+++ b/src/desktop/usb.rs
@@ -229,11 +229,11 @@ impl UsbDeviceEvent {
 /// This interface provides access to USB devices.
 #[derive(Debug)]
 #[doc(alias = "org.freedesktop.portal.Usb")]
-pub struct UsbProxy<'a>(Proxy<'a>);
+pub struct UsbProxy(Proxy<'static>);
 
-impl<'a> UsbProxy<'a> {
+impl UsbProxy {
     /// Create a new instance of [`UsbProxy`].
-    pub async fn new() -> Result<UsbProxy<'a>, Error> {
+    pub async fn new() -> Result<UsbProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Usb").await?;
         Ok(Self(proxy))
     }
@@ -247,7 +247,7 @@ impl<'a> UsbProxy<'a> {
     ///
     /// See also [`CreateSession`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Usb.html#org-freedesktop-portal-usb-createsession).
     #[doc(alias = "CreateSession")]
-    pub async fn create_session(&self) -> Result<Session<'a, Self>, Error> {
+    pub async fn create_session(&self) -> Result<Session<'static, Self>, Error> {
         let options = CreateSessionOptions::default();
         let session: OwnedObjectPath = self.0.call("CreateSession", &(&options)).await?;
         Session::new(session).await
@@ -367,5 +367,5 @@ impl<'a> UsbProxy<'a> {
     }
 }
 
-impl crate::Sealed for UsbProxy<'_> {}
-impl SessionPortal for UsbProxy<'_> {}
+impl crate::Sealed for UsbProxy {}
+impl SessionPortal for UsbProxy {}

--- a/src/desktop/wallpaper.rs
+++ b/src/desktop/wallpaper.rs
@@ -118,10 +118,10 @@ struct WallpaperOptions {
     set_on: Option<SetOn>,
 }
 
-struct WallpaperProxy<'a>(Proxy<'a>);
+struct WallpaperProxy(Proxy<'static>);
 
-impl<'a> WallpaperProxy<'a> {
-    pub async fn new() -> Result<WallpaperProxy<'a>, Error> {
+impl WallpaperProxy {
+    pub async fn new() -> Result<WallpaperProxy, Error> {
         let proxy = Proxy::new_desktop("org.freedesktop.portal.Wallpaper").await?;
         Ok(Self(proxy))
     }
@@ -161,8 +161,8 @@ impl<'a> WallpaperProxy<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for WallpaperProxy<'a> {
-    type Target = zbus::Proxy<'a>;
+impl std::ops::Deref for WallpaperProxy {
+    type Target = zbus::Proxy<'static>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
The various proxy types exposed by ashpd all wrap a `zbus::Proxy`. Since the `zbus::Proxy` type takes in a lifetime parameter, all the ashpd proxy types also take in a lifetime parameter.

This seems to make sense on the surface, but actually turns out to be unnecessary. The only thing the `zbus::Proxy` type uses the lifetime parameter for is a bus name, an object path and an interface name. All zbus proxy objects created by ashpd's wrappers use string constants (aka `&'static str`) for all interface names, bus names and object paths. That means we can always treat the wrapped zbus proxy objects as `zbus::Proxy<'static>`, so ashpd's wrapper types don't need to take in lifetime parameters.

This PR removes all the unnecessary lifetime parameters on ashpd's proxy types. This is technically a breaking change, as code which uses ashpd might explicitly pass in lifetimes to types which now don't take lifetime parameters. However it should result in a cleaner and more user friendly API overall while not reducing the expressive power of the API; removing the now-unnecessary lifetimes should be enough to fix any breakage introduced by this change.