### PR TITLE
builder: Request name after exporting interfaces

### DIFF
--- a/src/backend/builder.rs
+++ b/src/backend/builder.rs
@@ -176,7 +176,6 @@ impl Builder {
 
     pub async fn build(self) -> Result<()> {
         let cnx = zbus::Connection::session().await?;
-        cnx.request_name_with_flags(self.name, self.flags).await?;
 
         #[cfg(feature = "tokio")]
         let spawn = self.spawn.unwrap_or(Arc::new(super::spawn::TokioSpawner));
@@ -338,6 +337,8 @@ impl Builder {
                 .at("/org/freedesktop/portal/desktop", portal)
                 .await?;
         }
+
+        cnx.request_name_with_flags(self.name, self.flags).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This fixes the problem when XDP tries to launch our portal and do a `GetAll` but that method is never replied because no interfaces are available. This leads to blocking anything that uses XDP (like GTK apps).  Like in XDG Desktop Portal Phrosh - https://gitlab.gnome.org/World/Phosh/xdg-desktop-portal-phosh/-/issues/13.

Please see https://matrix.to/#/!uSaWOSkfhbBXoCCxYe:matrix.org/$UbbQeDdUir-2FoEisF94FhOVJk5bLvWvcyz9XYYbwgE?via=gnome.org&via=matrix.org&via=matrix.tait.tech for the conversation in zbus channel.

https://z-galaxy.github.io/zbus/service.html#-service-activation-pitfalls says that we either do this or switch to `Builder`. To me doing the request at last felt simpler, happy to improve :).