### PR TITLE
demo: cargo: Use libadwaita-rs v1_9 feature

### DIFF
--- a/ashpd-demo/Cargo.lock
+++ b/ashpd-demo/Cargo.lock
@@ -1493,9 +1493,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libadwaita"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df6715d1257bd8c093295b77a276ed129d73543b10304fec5829ced5d5b7c41"
+checksum = "fb09e12bf8f73342b3315c839d0a7668cc0ccebd78490c49fec48bab15d5484b"
 dependencies = [
  "gdk4",
  "gio",
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "libadwaita-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf8950090cc180250cdb1ff859a39748feeda7a53a9f28ead3a17a14cc37ae2"
+checksum = "6d7f94227ba87eb596fecada2491f04e357d507324142f77bf76d9e6be4a3e31"
 dependencies = [
  "gdk4-sys",
  "gio-sys",

--- a/ashpd-demo/Cargo.toml
+++ b/ashpd-demo/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 name = "ashpd-demo"
 
 [dependencies]
-adw = {version = "0.8", package = "libadwaita", features = ["v1_8"]}
+adw = {version = "0.8.1", package = "libadwaita", features = ["v1_9"]}
 anyhow = "1.0"
 ashpd = {git = "https://github.com/bilelmoussaoui/ashpd", default-features = false, features = ["async-std", "gtk4", "tracing", "pipewire"]}
 chrono = {version = "0.4", default-features = false, features = ["clock"]}


### PR DESCRIPTION
We depend on 1.9 in meson.build anyways.