### PR TITLE
cargo: Set resolver to 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 members = ["client", "demo/client", "demo/backend"]
 


### PR DESCRIPTION
This is the default since rust 2024. See
https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html for more details.