### PR TITLE
fix: Session::Closed signal being silently discarded

### DIFF
--- a/client/src/desktop/session.rs
+++ b/client/src/desktop/session.rs
@@ -67,7 +67,9 @@ where
     ///
     /// See also [`Closed`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Session.html#org-freedesktop-portal-session-closed).
     #[doc(alias = "Closed")]
-    pub async fn receive_closed(&self) -> Result<impl Stream<Item = ()>, Error> {
+    pub async fn receive_closed(
+        &self,
+    ) -> Result<impl Stream<Item = HashMap<String, OwnedValue>>, Error> {
         self.0.signal("Closed").await
     }
 


### PR DESCRIPTION
The signal was being silently discarded because ashpd was trying to deserialize to () while the signal is:

```
Closed (
  details a{sv}
)
```