### PR TITLE
clipboard: Enable InputCapture support for clipboards

### DIFF
--- a/client/src/desktop/clipboard.rs
+++ b/client/src/desktop/clipboard.rs
@@ -1,14 +1,17 @@
 //! Interact with the clipboard.
 //!
 //! The portal is mostly meant to be used along with
-//! [`RemoteDesktop`]
+//! [`RemoteDesktop`] or [`InputCapture`].
 
 use futures_util::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::{OwnedFd, OwnedObjectPath, Type, as_value, as_value::optional};
 
-use super::{Session, remote_desktop::RemoteDesktop};
+use super::{Session, SessionPortal};
 use crate::{Result, proxy::Proxy};
+
+/// A session that is compatible with the Clipboard portal
+pub trait IsClipboardSession: SessionPortal {}
 
 #[derive(Debug, Type, Serialize, Default)]
 #[zvariant(signature = "dict")]
@@ -83,9 +86,9 @@ impl Clipboard {
     ///
     /// See also [`RequestClipboard`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-requestclipboard).
     #[doc(alias = "RequestClipboard")]
-    pub async fn request(
+    pub async fn request<T: IsClipboardSession>(
         &self,
-        session: &Session<RemoteDesktop>,
+        session: &Session<T>,
         options: RequestClipboardOptions,
     ) -> Result<()> {
         self.0
@@ -98,9 +101,9 @@ impl Clipboard {
     ///
     /// See also [`SetSelection`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-setselection).
     #[doc(alias = "SetSelection")]
-    pub async fn set_selection<'a>(
+    pub async fn set_selection<'a, T: IsClipboardSession>(
         &self,
-        session: &Session<RemoteDesktop>,
+        session: &Session<T>,
         options: SetSelectionOptions<'a>,
     ) -> Result<()> {
         self.0
@@ -114,9 +117,9 @@ impl Clipboard {
     ///
     /// See also [`SelectionWrite`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-selectionwrite).
     #[doc(alias = "SelectionWrite")]
-    pub async fn selection_write(
+    pub async fn selection_write<T: IsClipboardSession>(
         &self,
-        session: &Session<RemoteDesktop>,
+        session: &Session<T>,
         serial: u32,
     ) -> Result<OwnedFd> {
         let fd = self
@@ -130,9 +133,9 @@ impl Clipboard {
     ///
     /// See also [`SelectionWriteDone`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-selectionwritedone).
     #[doc(alias = "SelectionWriteDone")]
-    pub async fn selection_write_done(
+    pub async fn selection_write_done<T: IsClipboardSession>(
         &self,
-        session: &Session<RemoteDesktop>,
+        session: &Session<T>,
         serial: u32,
         success: bool,
     ) -> Result<()> {
@@ -145,9 +148,9 @@ impl Clipboard {
     ///
     /// See also [`SelectionRead`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-selectionread).
     #[doc(alias = "SelectionRead")]
-    pub async fn selection_read(
+    pub async fn selection_read<T: IsClipboardSession>(
         &self,
-        session: &Session<RemoteDesktop>,
+        session: &Session<T>,
         mime_type: &str,
     ) -> Result<OwnedFd> {
         let fd = self
@@ -162,9 +165,9 @@ impl Clipboard {
     ///
     /// See also [`SelectionOwnerChanged`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-selectionownerchanged).
     #[doc(alias = "SelectionOwnerChanged")]
-    pub async fn receive_selection_owner_changed(
+    pub async fn receive_selection_owner_changed<T: IsClipboardSession>(
         &self,
-    ) -> Result<impl Stream<Item = (Session<RemoteDesktop>, SelectionOwnerChanged)>> {
+    ) -> Result<impl Stream<Item = (Session<T>, SelectionOwnerChanged)>> {
         let connection = self.connection().clone();
         Ok(self
             .0
@@ -185,9 +188,9 @@ impl Clipboard {
     ///
     /// See also [`SelectionTransfer`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Clipboard.html#org-freedesktop-portal-clipboard-selectiontransfer).
     #[doc(alias = "SelectionTransfer")]
-    pub async fn receive_selection_transfer(
+    pub async fn receive_selection_transfer<T: IsClipboardSession>(
         &self,
-    ) -> Result<impl Stream<Item = (Session<RemoteDesktop>, String, u32)>> {
+    ) -> Result<impl Stream<Item = (Session<T>, String, u32)>> {
         let connection = self.connection().clone();
         Ok(self
             .0

--- a/client/src/desktop/input_capture.rs
+++ b/client/src/desktop/input_capture.rs
@@ -937,3 +937,5 @@ impl std::ops::Deref for InputCapture {
 
 impl crate::Sealed for InputCapture {}
 impl SessionPortal for InputCapture {}
+#[cfg(feature = "clipboard")]
+impl crate::desktop::clipboard::IsClipboardSession for InputCapture {}

--- a/client/src/desktop/remote_desktop.rs
+++ b/client/src/desktop/remote_desktop.rs
@@ -759,3 +759,5 @@ impl std::ops::Deref for RemoteDesktop {
 
 impl crate::Sealed for RemoteDesktop {}
 impl SessionPortal for RemoteDesktop {}
+#[cfg(feature = "clipboard")]
+impl crate::desktop::clipboard::IsClipboardSession for RemoteDesktop {}


### PR DESCRIPTION
Allow different session types in the clipboard session which enables us to use a clipboard in the InputCapture session.