### PR TITLE
clipboard: Use set_mime_types in SetSelectionOptions

### DIFF
--- a/client/src/desktop/clipboard.rs
+++ b/client/src/desktop/clipboard.rs
@@ -25,7 +25,7 @@ pub struct SetSelectionOptions<'a> {
 
 impl<'a> SetSelectionOptions<'a> {
     /// Sets the mime types for the clipboard selection.
-    pub fn mime_types(mut self, mime_types: &'a [&'a str]) -> Self {
+    pub fn set_mime_types(mut self, mime_types: &'a [&'a str]) -> Self {
         self.mime_types = mime_types;
         self
     }


### PR DESCRIPTION
Convention is that setters in options are set_foo(), getters in options are just foo().

Fixes: f1407ee0a79e ("clipboard: Add missing mime types setter to SetSelectionOptions")