### PR TITLE
inputcapture: Add persist_mode and restore_token to Start

### DIFF
--- a/client/src/desktop/input_capture.rs
+++ b/client/src/desktop/input_capture.rs
@@ -303,7 +303,7 @@ use zbus::zvariant::{
     as_value::{self, optional},
 };
 
-use super::{HandleToken, Request, Session, session::SessionPortal};
+use super::{HandleToken, PersistMode, Request, Session, session::SessionPortal};
 use crate::{Error, WindowIdentifier, proxy::Proxy};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Debug, Copy, Clone, Type)]
@@ -371,6 +371,10 @@ pub struct StartOptions {
     handle_token: HandleToken,
     #[serde(with = "as_value")]
     capabilities: BitFlags<Capabilities>,
+    #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
+    restore_token: Option<String>,
+    #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
+    persist_mode: Option<PersistMode>,
 }
 
 impl StartOptions {
@@ -379,16 +383,37 @@ impl StartOptions {
         self.capabilities = capabilities;
         self
     }
+
+    /// Sets the restore token from a previous session.
+    ///
+    /// If the stored session cannot be restored, this value is ignored
+    /// and the user will be prompted normally.
+    ///
+    /// The restore token is invalidated after using it once. To restore
+    /// the same session again, use the new restore token sent in the
+    /// [`StartResponse`].
+    pub fn set_restore_token<'a>(mut self, token: impl Into<Option<&'a str>>) -> Self {
+        self.restore_token = token.into().map(ToOwned::to_owned);
+        self
+    }
+
+    /// Sets the persist mode for this session.
+    pub fn set_persist_mode(mut self, persist_mode: impl Into<Option<PersistMode>>) -> Self {
+        self.persist_mode = persist_mode.into();
+        self
+    }
 }
 
 #[derive(Debug, Deserialize, Type)]
 #[zvariant(signature = "dict")]
-/// Response of [`InputCapture::create_session`] request.
+/// Response of [`InputCapture::start`] request.
 pub struct StartResponse {
     #[serde(with = "as_value")]
     capabilities: BitFlags<Capabilities>,
     #[serde(default, with = "optional")]
     clipboard_enabled: Option<bool>,
+    #[serde(default, with = "optional")]
+    restore_token: Option<String>,
 }
 
 impl StartResponse {
@@ -400,6 +425,15 @@ impl StartResponse {
     /// Whether the clipboard was enabled.
     pub fn is_clipboard_enabled(&self) -> bool {
         self.clipboard_enabled.unwrap_or(false)
+    }
+
+    /// The session restore token, if the session was started with a
+    /// [`PersistMode`] other than [`PersistMode::DoNot`].
+    ///
+    /// This token can be passed to [`StartOptions::set_restore_token`] to
+    /// restore the session without prompting the user again.
+    pub fn restore_token(&self) -> Option<&str> {
+        self.restore_token.as_deref()
     }
 }
 

--- a/client/src/desktop/mod.rs
+++ b/client/src/desktop/mod.rs
@@ -153,12 +153,20 @@ pub mod wallpaper;
 )]
 #[cfg_attr(
     docsrs,
-    doc(cfg(any(feature = "screencast", feature = "remote_desktop")))
+    doc(cfg(any(
+        feature = "screencast",
+        feature = "remote_desktop",
+        feature = "input_capture"
+    )))
 )]
-#[cfg(any(feature = "screencast", feature = "remote_desktop"))]
+#[cfg(any(
+    feature = "screencast",
+    feature = "remote_desktop",
+    feature = "input_capture"
+))]
 #[doc(alias = "XdpPersistMode")]
 #[repr(u32)]
-/// Persistence mode for a screencast or remote desktop session.
+/// Persistence mode for a screencast, remote desktop, or input capture session.
 pub enum PersistMode {
     #[doc(alias = "XDP_PERSIST_MODE_NONE")]
     #[default]


### PR DESCRIPTION
## Summary

Add session persistence support to InputCapture's `Start` method, mirroring how RemoteDesktop and ScreenCast already handle it.

The xdg-desktop-portal spec ([PR #1898](https://github.com/flatpak/xdg-desktop-portal/pull/1898), merged Feb 25 2026) defines `persist_mode` and `restore_token` as options on the InputCapture `Start` method (added in interface version 2). The recent `CreateSession2` work landed these new session creation methods, but the persistence parameters on `Start` were not yet added.

## Changes

- **`StartOptions`**: Add `restore_token: Option<String>` and `persist_mode: Option<PersistMode>` fields with `set_restore_token()` and `set_persist_mode()` builder methods
- **`StartResponse`**: Add `restore_token: Option<String>` field with `restore_token()` accessor  
- **`PersistMode`**: Widen feature gate from `screencast | remote_desktop` to also include `input_capture`
- Fix `StartResponse` doc comment (was incorrectly referencing `create_session`)

## Context

This completes the InputCapture persistence API surface — applications can now use the typed ashpd API for the full persistence flow (`CreateSession2` → `Start` with `persist_mode`/`restore_token` → read `restore_token` from response) instead of falling back to raw zbus calls.

The serde attribute patterns follow the existing conventions used by `SelectDevicesOptions` / `SelectedDevices` in the remote desktop module and `SelectSourcesOptions` / `Streams` in the screencast module.