### PR TITLE
Add missing default implementation for ConfigureShortcutsOptions

### DIFF
--- a/client/src/desktop/global_shortcuts.rs
+++ b/client/src/desktop/global_shortcuts.rs
@@ -115,7 +115,7 @@ impl BindShortcuts {
     }
 }
 
-#[derive(Serialize, Type, Debug)]
+#[derive(Serialize, Type, Debug, Default)]
 #[zvariant(signature = "dict")]
 /// Specified options for a [`GlobalShortcuts::configure_shortcuts`] request.
 pub struct ConfigureShortcutsOptions {


### PR DESCRIPTION
Add a way to create a new instance of ConfigureShortcutsOptions. Otherwise there is no way to consume it.