### PR TITLE
demo: settings: Use property class

### DIFF
--- a/demo/client/src/portals/desktop/settings.rs
+++ b/demo/client/src/portals/desktop/settings.rs
@@ -133,20 +133,13 @@ impl SettingsPage {
             let group = adw::PreferencesGroup::builder().title(&namespace).build();
 
             for (key, value) in settings_map {
-                let row = adw::ActionRow::builder().title(&key).build();
-
                 let formatted_value = format_value(&value);
 
-                let value_label = gtk::Label::builder()
-                    .label(formatted_value)
-                    .halign(gtk::Align::Start)
-                    .valign(gtk::Align::Center)
-                    .selectable(true)
-                    .ellipsize(gtk::pango::EllipsizeMode::End)
-                    .xalign(0.0)
+                let row = adw::ActionRow::builder()
+                    .title(&key)
+                    .subtitle(&formatted_value)
                     .build();
-                value_label.add_css_class("dim-label");
-                row.add_suffix(&value_label);
+                row.add_css_class("property");
 
                 group.add(&row);
             }


### PR DESCRIPTION
This is more mobile friendly.

<img width="850" height="850" alt="image" src="https://github.com/user-attachments/assets/785cf79c-3752-4f8b-b579-8440c4f14bfc" />
