### PR TITLE
Lower rust-version from 1.92 to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["portal", "flatpak", "xdg", "desktop", "dbus"]
 license = "MIT"
 repository = "https://github.com/bilelmoussaoui/ashpd"
 version = "0.13.0"
-rust-version = "1.92"
 
 [workspace.dependencies]
 zvariant = { version = "5.8", default-features = false, features = [

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 name = "ashpd"
 repository.workspace = true
 version.workspace = true
-rust-version.workspace = true
+rust-version = "1.87"
 
 [features]
 async-io = ["zbus/async-io", "futures-util/io"]

--- a/demo/backend/Cargo.toml
+++ b/demo/backend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ashpd-backend-demo"
 version = "0.1.0"
 edition.workspace = true
+rust-version = "1.87"
 license.workspace = true
 
 [dependencies]

--- a/demo/client/Cargo.toml
+++ b/demo/client/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>"]
 edition = "2024"
 license = "MIT"
 name = "ashpd-demo"
+rust-version = "1.92"
 version = "0.1.0"
 
 [dependencies]


### PR DESCRIPTION
Closes #394

The ashpd source code does not use any language features beyond Rust 1.85. The actual MSRV floor is driven by zbus 5.14 at 1.87. Edition 2024 was stabilized in Rust 1.85 and is fully compatible with rust-version 1.87. These are not exclusive.

This one-line change unblocks distribution packaging on Fedora 43 (rustc 1.90), RHEL 9 (rustc 1.88), and brings Debian 13 (rustc 1.85) within two minor versions which are backported adn therefore doable..

The rust-version was bumped from 1.75 to 1.92 in PR #320 alongside the workspace restructuring, but the code itself does not require anything above the zbus dependency floor.