### PR TITLE
Add Portuguese translation

### DIFF
--- a/demo/client/po/LINGUAS
+++ b/demo/client/po/LINGUAS
@@ -1,4 +1,5 @@
 kk
+pt
 pt_BR
 sl
 sv

--- a/demo/client/po/pt.po
+++ b/demo/client/po/pt.po
@@ -1,0 +1,177 @@
+# Portuguese translation for ashpd.
+# Copyright (C) 2026 ashpd's COPYRIGHT HOLDER
+# This file is distributed under the same license as the ashpd package.
+# André Moreira <afrmscb@gmail.com>, 2026.
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2020-2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ashpd main\n"
+"Report-Msgid-Bugs-To: https://github.com/bilelmoussaoui/ashpd/issues\n"
+"POT-Creation-Date: 2026-03-19 15:24+0000\n"
+"PO-Revision-Date: 2026-03-23 14:55+0000\n"
+"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
+"Language-Team: Portuguese <pt@li.org>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
+
+#: ../src/main.rs:40
+msgid "ASHPD Demo"
+msgstr "Demonstração ASHPD"
+
+#: ../src/portals/desktop/file_chooser.rs:132
+msgid "Choice ID"
+msgstr "ID da escolha"
+
+#: ../src/portals/desktop/file_chooser.rs:135
+#: ../src/portals/desktop/notification.rs:446
+msgid "Label"
+msgstr "Etiqueta"
+
+#: ../src/portals/desktop/file_chooser.rs:138
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/portals/desktop/file_chooser.rs:140
+msgid "Boolean"
+msgstr "Booleano"
+
+#: ../src/portals/desktop/file_chooser.rs:141
+msgid "Dropdown"
+msgstr "Menu suspenso"
+
+#: ../src/portals/desktop/file_chooser.rs:154
+msgid "Initial State"
+msgstr "Estado inicial"
+
+#: ../src/portals/desktop/file_chooser.rs:158
+msgid "Initial Selection"
+msgstr "Seleção inicial"
+
+#: ../src/portals/desktop/file_chooser.rs:167
+msgid "Options"
+msgstr "Opções"
+
+#: ../src/portals/desktop/file_chooser.rs:168
+msgid "One option per line: key=value"
+msgstr "Uma opção por linha: chave=valor"
+
+#: ../src/portals/desktop/file_chooser.rs:206
+#: ../src/portals/desktop/notification.rs:472
+msgid "Remove"
+msgstr "Remover"
+
+#: ../src/portals/desktop/file_chooser.rs:338
+msgid "File Encoding"
+msgstr "Codificação do ficheiro"
+
+#: ../src/portals/desktop/file_chooser.rs:355
+msgid "Compress File"
+msgstr "Comprimir ficheiro"
+
+#: ../src/portals/desktop/file_chooser.rs:373
+msgid "Create Archive"
+msgstr "Criar arquivo"
+
+#: ../src/portals/desktop/file_chooser.rs:456
+msgid "Text files"
+msgstr "Ficheiros de texto"
+
+#: ../src/portals/desktop/file_chooser.rs:462
+#: ../src/portals/desktop/wallpaper.rs:81
+msgid "Images"
+msgstr "Imagens"
+
+#: ../src/portals/desktop/file_chooser.rs:465
+msgid "Videos"
+msgstr "Vídeos"
+
+#: ../src/portals/desktop/notification.rs:112
+msgid "View"
+msgstr "Ver"
+
+#: ../src/portals/desktop/notification.rs:125
+msgid "Dismiss"
+msgstr "Dispensar"
+
+#: ../src/portals/desktop/notification.rs:177
+msgid "Audio files"
+msgstr "Ficheiros de áudio"
+
+#: ../src/portals/desktop/notification.rs:184
+#: ../src/portals/desktop/wallpaper.rs:88
+msgid "Select"
+msgstr "Selecionar"
+
+#: ../src/portals/desktop/notification.rs:186
+msgid "Notification Sound"
+msgstr "Som de notificação"
+
+#: ../src/portals/desktop/notification.rs:324
+msgid "Notification sent"
+msgstr "Notificação enviada"
+
+#: ../src/portals/desktop/notification.rs:448
+msgid "Action"
+msgstr "Ação"
+
+#: ../src/portals/desktop/notification.rs:450
+msgid "Action Target"
+msgstr "Alvo da ação"
+
+#: ../src/portals/desktop/notification.rs:453
+msgid "Purpose"
+msgstr "Finalidade"
+
+#: ../src/portals/desktop/notification.rs:455
+msgid "None"
+msgstr "Nenhum"
+
+#: ../src/portals/desktop/notification.rs:456
+msgid "IM Reply with Text"
+msgstr "Resposta de MI com texto"
+
+#: ../src/portals/desktop/notification.rs:457
+msgid "Call Accept"
+msgstr "Aceitar chamada"
+
+#: ../src/portals/desktop/notification.rs:458
+msgid "Call Decline"
+msgstr "Recusar chamada"
+
+#: ../src/portals/desktop/notification.rs:459
+msgid "Call Hang Up"
+msgstr "Desligar chamada"
+
+#: ../src/portals/desktop/notification.rs:460
+msgid "Call Enable Speakerphone"
+msgstr "Ativar alta-voz"
+
+#: ../src/portals/desktop/notification.rs:461
+msgid "Call Disable Speakerphone"
+msgstr "Desativar alta-voz"
+
+#: ../src/portals/desktop/notification.rs:462
+msgid "System Custom Alert"
+msgstr "Alerta personalizado do sistema"
+
+#: ../src/portals/desktop/settings.rs:136
+msgid "Enabled"
+msgstr "Ativado"
+
+#: ../src/portals/desktop/settings.rs:138
+msgid "Disabled"
+msgstr "Desativado"
+
+#: ../src/update_window.rs:117
+msgid "Starting update…"
+msgstr "A iniciar atualização…"
+
+#: ../src/update_window.rs:181
+#, rust-format
+msgid "Operation {} of {}"
+msgstr "Operação {} de {}"


### PR DESCRIPTION
Add translation in Portuguese from Damned Lies: https://l10n.gnome.org/vertimus/7475/1816/55/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.