### PR TITLE
Add Serbian translation

### DIFF
--- a/demo/client/po/LINGUAS
+++ b/demo/client/po/LINGUAS
@@ -2,5 +2,6 @@ kk
 pt
 pt_BR
 sl
+sr
 sv
 uk

--- a/demo/client/po/sr.po
+++ b/demo/client/po/sr.po
@@ -1,0 +1,176 @@
+# Serbian translation for ashpd.
+# Copyright (C) 2026 ashpd's COPYRIGHT HOLDER
+# This file is distributed under the same license as the ashpd package.
+# Марко Костић <marko.m.kostic@gmail.com>,  2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ashpd main\n"
+"Report-Msgid-Bugs-To: https://github.com/bilelmoussaoui/ashpd/issues\n"
+"POT-Creation-Date: 2026-03-25 15:25+0000\n"
+"PO-Revision-Date: 2026-03-26 00:40+0100\n"
+"Last-Translator: Марко М. Костић <marko.m.kostic@gmail.com>\n"
+"Language-Team: Serbian <Serbian>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 3.9\n"
+
+#: ../src/main.rs:40
+msgid "ASHPD Demo"
+msgstr "ASHPD демо"
+
+#: ../src/portals/desktop/file_chooser.rs:132
+msgid "Choice ID"
+msgstr "ИД избора"
+
+#: ../src/portals/desktop/file_chooser.rs:135
+#: ../src/portals/desktop/notification.rs:446
+msgid "Label"
+msgstr "Ознака"
+
+#: ../src/portals/desktop/file_chooser.rs:138
+msgid "Type"
+msgstr "Тип"
+
+#: ../src/portals/desktop/file_chooser.rs:140
+msgid "Boolean"
+msgstr "Boolean"
+
+#: ../src/portals/desktop/file_chooser.rs:141
+msgid "Dropdown"
+msgstr "Падајући мени"
+
+#: ../src/portals/desktop/file_chooser.rs:154
+msgid "Initial State"
+msgstr "Почетно стање"
+
+#: ../src/portals/desktop/file_chooser.rs:158
+msgid "Initial Selection"
+msgstr "Почетни избор"
+
+#: ../src/portals/desktop/file_chooser.rs:167
+msgid "Options"
+msgstr "Опције"
+
+#: ../src/portals/desktop/file_chooser.rs:168
+msgid "One option per line: key=value"
+msgstr "Једна опција по линији: кључ=вредност"
+
+#: ../src/portals/desktop/file_chooser.rs:206
+#: ../src/portals/desktop/notification.rs:472
+msgid "Remove"
+msgstr "Уклони"
+
+#: ../src/portals/desktop/file_chooser.rs:338
+msgid "File Encoding"
+msgstr "Кодирање датотеке"
+
+#: ../src/portals/desktop/file_chooser.rs:355
+msgid "Compress File"
+msgstr "Запакуј датотеку"
+
+#: ../src/portals/desktop/file_chooser.rs:373
+msgid "Create Archive"
+msgstr "Направи архиву"
+
+#: ../src/portals/desktop/file_chooser.rs:456
+msgid "Text files"
+msgstr "Текстуалне датотеке"
+
+#: ../src/portals/desktop/file_chooser.rs:462
+#: ../src/portals/desktop/wallpaper.rs:81
+msgid "Images"
+msgstr "Слике"
+
+#: ../src/portals/desktop/file_chooser.rs:465
+msgid "Videos"
+msgstr "Видеи"
+
+#: ../src/portals/desktop/notification.rs:112
+msgid "View"
+msgstr "Преглед"
+
+#: ../src/portals/desktop/notification.rs:125
+msgid "Dismiss"
+msgstr "Одбаци"
+
+#: ../src/portals/desktop/notification.rs:177
+msgid "Audio files"
+msgstr "Аудио датотеке"
+
+#: ../src/portals/desktop/notification.rs:184
+#: ../src/portals/desktop/wallpaper.rs:88
+msgid "Select"
+msgstr "Изабери"
+
+#: ../src/portals/desktop/notification.rs:186
+msgid "Notification Sound"
+msgstr "Звук обавештења"
+
+#: ../src/portals/desktop/notification.rs:324
+msgid "Notification sent"
+msgstr "Обавештење је послато"
+
+#: ../src/portals/desktop/notification.rs:448
+msgid "Action"
+msgstr "Радња"
+
+#: ../src/portals/desktop/notification.rs:450
+msgid "Action Target"
+msgstr "Мета радње"
+
+#: ../src/portals/desktop/notification.rs:453
+msgid "Purpose"
+msgstr "Сврха"
+
+#: ../src/portals/desktop/notification.rs:455
+msgid "None"
+msgstr "Ништа"
+
+#: ../src/portals/desktop/notification.rs:456
+msgid "IM Reply with Text"
+msgstr "Текстуални одговор на тренутну поруку"
+
+#: ../src/portals/desktop/notification.rs:457
+msgid "Call Accept"
+msgstr "Прихвати позив"
+
+#: ../src/portals/desktop/notification.rs:458
+msgid "Call Decline"
+msgstr "Одбиј позив"
+
+#: ../src/portals/desktop/notification.rs:459
+msgid "Call Hang Up"
+msgstr "Прекини позив"
+
+#: ../src/portals/desktop/notification.rs:460
+msgid "Call Enable Speakerphone"
+msgstr "Укључи звучник"
+
+#: ../src/portals/desktop/notification.rs:461
+msgid "Call Disable Speakerphone"
+msgstr "Искључи звучник"
+
+#: ../src/portals/desktop/notification.rs:462
+msgid "System Custom Alert"
+msgstr "Произвољно системско упозорење"
+
+#: ../src/portals/desktop/settings.rs:136
+msgid "Enabled"
+msgstr "Омогућено"
+
+#: ../src/portals/desktop/settings.rs:138
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: ../src/update_window.rs:117
+msgid "Starting update…"
+msgstr "Покрећем ажурирање…"
+
+#: ../src/update_window.rs:181
+#, rust-format
+msgid "Operation {} of {}"
+msgstr "Радња {} од {}"


### PR DESCRIPTION
Add translation in Serbian from Damned Lies: https://l10n.gnome.org/vertimus/7475/1816/107/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.