### PR TITLE
app-chooser: Allow to build DesktopID from AppID

### DIFF
--- a/client/src/backend/app_chooser.rs
+++ b/client/src/backend/app_chooser.rs
@@ -28,6 +28,12 @@ impl DesktopID {
     }
 }
 
+impl From<AppID> for DesktopID {
+    fn from(value: AppID) -> Self {
+        Self(Ok(value))
+    }
+}
+
 impl Serialize for DesktopID {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This makes it simple to construct a desktop-id from an app-id.

Maybe I'm missing something but I think that is needed to return `DesktopId` in a backend implementation.