### PR TITLE
app-chooser: Allow `DesktopID` from strings

### DIFF
--- a/client/src/backend/app_chooser.rs
+++ b/client/src/backend/app_chooser.rs
@@ -34,6 +34,18 @@ impl From<AppID> for DesktopID {
     }
 }
 
+impl From<String> for DesktopID {
+    fn from(value: String) -> Self {
+        Self(value.parse::<AppID>().or(Err(value)))
+    }
+}
+
+impl From<&str> for DesktopID {
+    fn from(value: &str) -> Self {
+        Self(value.parse::<AppID>().or(Err(String::from(value))))
+    }
+}
+
 impl Serialize for DesktopID {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
If the chosen application has an invalid ID, then we can never create a `DesktopID` out of it as:
1. The only way to create `DesktopID` is from `AppID`.
2. `AppID` itself can not be created using an invalid ID.

So let us allow creating `DesktopID` directly from strings. Hopefully I did not miss anything.