### PR TITLE
tree: Use `DesktopID` for all backends

### DIFF
--- a/client/src/app_id.rs
+++ b/client/src/app_id.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, str::FromStr};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use zbus::zvariant::{self, Basic, Type};
 
 /// The application ID.
@@ -84,6 +84,77 @@ impl<'de> Deserialize<'de> for AppID {
         app_id
             .parse::<Self>()
             .map_err(|err| serde::de::Error::custom(err.to_string()))
+    }
+}
+
+/// The application ID or the desktop file name without .desktop suffix.
+///
+/// As unsandboxed applications might not be defining a strict application ID,
+/// this type allows the backend implementation to fallback to the inner string
+/// without causing an error and manually handle those applications.
+#[derive(Debug, Eq, Hash, PartialEq, Type)]
+#[zvariant(signature = "s")]
+pub struct MaybeAppID(Result<AppID, String>);
+
+impl MaybeAppID {
+    /// Returns the inner value. If the ID is valid, then `Ok` contains the
+    /// `AppID` else `Err` contains the invalid app ID as string.
+    pub fn inner(&self) -> &Result<AppID, String> {
+        &self.0
+    }
+}
+
+impl zvariant::NoneValue for MaybeAppID {
+    type NoneType = String;
+
+    fn null_value() -> String {
+        String::default()
+    }
+}
+
+impl From<AppID> for MaybeAppID {
+    fn from(value: AppID) -> Self {
+        Self(Ok(value))
+    }
+}
+
+impl From<String> for MaybeAppID {
+    fn from(value: String) -> Self {
+        Self(value.parse::<AppID>().or(Err(value)))
+    }
+}
+
+impl From<&str> for MaybeAppID {
+    fn from(value: &str) -> Self {
+        Self(value.parse::<AppID>().or(Err(String::from(value))))
+    }
+}
+
+impl Serialize for MaybeAppID {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for MaybeAppID {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner = String::deserialize(deserializer)?;
+        Ok(Self(inner.parse::<AppID>().or(Err(inner))))
+    }
+}
+
+impl std::fmt::Display for MaybeAppID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Ok(app_id) => f.write_str(app_id),
+            Err(app_id) => f.write_str(app_id),
+        }
     }
 }
 

--- a/client/src/backend/access.rs
+++ b/client/src/backend/access.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -104,7 +104,7 @@ pub trait AccessImpl: RequestImpl {
     async fn access_dialog(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: String,
         subtitle: String,
@@ -141,7 +141,7 @@ impl AccessInterface {
     async fn access_dialog(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         subtitle: String,

--- a/client/src/backend/account.rs
+++ b/client/src/backend/account.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -22,7 +22,7 @@ pub trait AccountImpl: RequestImpl {
     async fn get_user_information(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         options: UserInformationOptions,
     ) -> Result<UserInformation>;
@@ -56,7 +56,7 @@ impl AccountInterface {
     async fn get_user_information(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: UserInformationOptions,
     ) -> Result<Response<UserInformation>> {

--- a/client/src/backend/app_chooser.rs
+++ b/client/src/backend/app_chooser.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    ActivationToken, AppID, PortalError, Uri, WindowIdentifierType,
+    ActivationToken, MaybeAppID, PortalError, Uri, WindowIdentifierType,
     backend::request::{Request, RequestImpl},
     desktop::{HandleToken, Response},
     zvariant::{
@@ -13,72 +13,11 @@ use crate::{
     },
 };
 
-/// The desktop ID of an application.
-///
-/// This is the name of application's desktop entry file without the `.desktop`
-/// suffix. This ID may or may not follow the [application ID
-/// guidelines](https://developer.gnome.org/documentation/tutorials/application-id.html).
-#[derive(Debug, Type)]
-#[zvariant(signature = "s")]
-pub struct DesktopID(Result<AppID, String>);
-
-impl DesktopID {
-    pub fn inner(&self) -> &Result<AppID, String> {
-        &self.0
-    }
-}
-
-impl From<AppID> for DesktopID {
-    fn from(value: AppID) -> Self {
-        Self(Ok(value))
-    }
-}
-
-impl From<String> for DesktopID {
-    fn from(value: String) -> Self {
-        Self(value.parse::<AppID>().or(Err(value)))
-    }
-}
-
-impl From<&str> for DesktopID {
-    fn from(value: &str) -> Self {
-        Self(value.parse::<AppID>().or(Err(String::from(value))))
-    }
-}
-
-impl Serialize for DesktopID {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.to_string().as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for DesktopID {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let inner = String::deserialize(deserializer)?;
-        Ok(Self(inner.parse::<AppID>().or(Err(inner))))
-    }
-}
-
-impl std::fmt::Display for DesktopID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            Ok(app_id) => f.write_str(app_id),
-            Err(app_id) => f.write_str(app_id),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Type)]
 #[zvariant(signature = "dict")]
 pub struct ChooserOptions {
     #[serde(default, with = "optional")]
-    last_choice: Option<DesktopID>,
+    last_choice: Option<MaybeAppID>,
     #[serde(default, with = "optional")]
     modal: Option<bool>,
     #[serde(default, with = "optional")]
@@ -92,7 +31,7 @@ pub struct ChooserOptions {
 }
 
 impl ChooserOptions {
-    pub fn last_choice(&self) -> Option<&DesktopID> {
+    pub fn last_choice(&self) -> Option<&MaybeAppID> {
         self.last_choice.as_ref()
     }
 
@@ -121,13 +60,13 @@ impl ChooserOptions {
 #[zvariant(signature = "dict")]
 pub struct Choice {
     #[serde(with = "as_value")]
-    choice: DesktopID,
+    choice: MaybeAppID,
     #[serde(with = "optional", skip_serializing_if = "Option::is_none")]
     activation_token: Option<ActivationToken>,
 }
 
 impl Choice {
-    pub fn new(choice: DesktopID) -> Self {
+    pub fn new(choice: MaybeAppID) -> Self {
         Self {
             choice,
             activation_token: None,
@@ -150,9 +89,9 @@ pub trait AppChooserImpl: RequestImpl {
     async fn choose_application(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         parent_window: Option<WindowIdentifierType>,
-        choices: Vec<DesktopID>,
+        choices: Vec<MaybeAppID>,
         options: ChooserOptions,
     ) -> Result<Choice, PortalError>;
 
@@ -160,7 +99,7 @@ pub trait AppChooserImpl: RequestImpl {
     async fn update_choices(
         &self,
         token: HandleToken,
-        choices: Vec<DesktopID>,
+        choices: Vec<MaybeAppID>,
     ) -> Result<(), PortalError>;
 }
 
@@ -191,9 +130,9 @@ impl AppChooserInterface {
     async fn choose_application(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         parent_window: Optional<WindowIdentifierType>,
-        choices: Vec<DesktopID>,
+        choices: Vec<MaybeAppID>,
         options: ChooserOptions,
     ) -> Result<Response<Choice>, PortalError> {
         let imp = Arc::clone(&self.imp);
@@ -221,7 +160,7 @@ impl AppChooserInterface {
     async fn update_choices(
         &self,
         handle: OwnedObjectPath,
-        choices: Vec<DesktopID>,
+        choices: Vec<MaybeAppID>,
     ) -> Result<(), PortalError> {
         #[cfg(feature = "tracing")]
         tracing::debug!("AppChooser::UpdateChoices");

--- a/client/src/backend/background.rs
+++ b/client/src/backend/background.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
-    AppID, PortalError,
+    MaybeAppID, PortalError,
     backend::request::{Request, RequestImpl},
     desktop::{HandleToken, Response},
     zbus::object_server::SignalEmitter,
@@ -58,20 +58,20 @@ pub trait BackgroundSignalEmitter: Send + Sync {
 #[async_trait]
 pub trait BackgroundImpl: RequestImpl {
     #[doc(alias = "GetAppState")]
-    async fn get_app_state(&self) -> Result<HashMap<AppID, AppState>, PortalError>;
+    async fn get_app_state(&self) -> Result<HashMap<MaybeAppID, AppState>, PortalError>;
 
     #[doc(alias = "NotifyBackground")]
     async fn notify_background(
         &self,
         token: HandleToken,
-        app_id: AppID,
+        app_id: MaybeAppID,
         name: &str,
     ) -> Result<Background, PortalError>;
 
     #[doc(alias = "EnableAutostart")]
     async fn enable_autostart(
         &self,
-        app_id: AppID,
+        app_id: MaybeAppID,
         enable: bool,
         commandline: Vec<String>,
         flags: BitFlags<AutoStartFlags>,
@@ -120,7 +120,7 @@ impl BackgroundInterface {
     }
 
     #[zbus(out_args("apps"))]
-    async fn get_app_state(&self) -> Result<HashMap<AppID, AppState>, PortalError> {
+    async fn get_app_state(&self) -> Result<HashMap<MaybeAppID, AppState>, PortalError> {
         #[cfg(feature = "tracing")]
         tracing::debug!("Background::GetAppState");
 
@@ -135,7 +135,7 @@ impl BackgroundInterface {
     async fn notify_background(
         &self,
         handle: OwnedObjectPath,
-        app_id: AppID,
+        app_id: MaybeAppID,
         name: String,
     ) -> Result<Response<Background>, PortalError> {
         let imp = Arc::clone(&self.imp);
@@ -157,7 +157,7 @@ impl BackgroundInterface {
     #[zbus(out_args("result"))]
     async fn enable_autostart(
         &self,
-        app_id: AppID,
+        app_id: MaybeAppID,
         enable: bool,
         commandline: Vec<String>,
         flags: BitFlags<AutoStartFlags>,

--- a/client/src/backend/email.rs
+++ b/client/src/backend/email.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -18,7 +18,7 @@ pub trait EmailImpl: RequestImpl {
     async fn compose(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         options: EmailOptions,
     ) -> Result<()>;
@@ -51,7 +51,7 @@ impl EmailInterface {
     async fn compose_email(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: EmailOptions,
     ) -> Result<Response<()>> {

--- a/client/src/backend/file_chooser.rs
+++ b/client/src/backend/file_chooser.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -22,7 +22,7 @@ pub trait FileChooserImpl: RequestImpl {
     async fn open_file(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
         options: OpenFileOptions,
@@ -32,7 +32,7 @@ pub trait FileChooserImpl: RequestImpl {
     async fn save_file(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
         options: SaveFileOptions,
@@ -42,7 +42,7 @@ pub trait FileChooserImpl: RequestImpl {
     async fn save_files(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         title: &str,
         options: SaveFilesOptions,
@@ -76,7 +76,7 @@ impl FileChooserInterface {
     async fn open_file(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: OpenFileOptions,
@@ -107,7 +107,7 @@ impl FileChooserInterface {
     async fn save_file(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: SaveFileOptions,
@@ -138,7 +138,7 @@ impl FileChooserInterface {
     async fn save_files(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: SaveFilesOptions,

--- a/client/src/backend/permission_store.rs
+++ b/client/src/backend/permission_store.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 
 use crate::{
-    AppID, PortalError,
+    MaybeAppID, PortalError,
     documents::{DocumentID, Permission},
     zbus::object_server::SignalEmitter,
     zvariant::{OwnedValue, Value},
@@ -17,7 +17,7 @@ pub trait PermissionStoreSignalEmitter: Send + Sync {
         id: DocumentID,
         deleted: bool,
         data: Value<'_>,
-        permissions: HashMap<AppID, Vec<Permission>>,
+        permissions: HashMap<MaybeAppID, Vec<Permission>>,
     ) -> zbus::Result<()>;
 }
 
@@ -28,7 +28,7 @@ pub trait PermissionStoreImpl: Send + Sync {
         &self,
         table: &str,
         id: DocumentID,
-    ) -> Result<(HashMap<AppID, Vec<Permission>>, OwnedValue), PortalError>;
+    ) -> Result<(HashMap<MaybeAppID, Vec<Permission>>, OwnedValue), PortalError>;
 
     #[doc(alias = "Set")]
     async fn set(
@@ -36,7 +36,7 @@ pub trait PermissionStoreImpl: Send + Sync {
         table: &str,
         create: bool,
         id: DocumentID,
-        app_permissions: HashMap<AppID, Vec<Permission>>,
+        app_permissions: HashMap<MaybeAppID, Vec<Permission>>,
         data: Value<'_>,
     ) -> Result<(), PortalError>;
 
@@ -60,7 +60,7 @@ pub trait PermissionStoreImpl: Send + Sync {
         &self,
         table: &str,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
     ) -> Result<Vec<Permission>, PortalError>;
 
     #[doc(alias = "SetPermission")]
@@ -69,7 +69,7 @@ pub trait PermissionStoreImpl: Send + Sync {
         table: &str,
         create: bool,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
         permissions: Vec<Permission>,
     ) -> Result<(), PortalError>;
 
@@ -78,7 +78,7 @@ pub trait PermissionStoreImpl: Send + Sync {
         &self,
         table: &str,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
     ) -> Result<(), PortalError>;
 
     // Set the signal emitter, allowing to notify of changes.
@@ -108,7 +108,7 @@ impl PermissionStoreInterface {
         id: DocumentID,
         deleted: bool,
         data: Value<'_>,
-        permissions: HashMap<AppID, Vec<Permission>>,
+        permissions: HashMap<MaybeAppID, Vec<Permission>>,
     ) -> zbus::Result<()> {
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
@@ -135,7 +135,7 @@ impl PermissionStoreSignalEmitter for PermissionStoreInterface {
         id: DocumentID,
         deleted: bool,
         data: Value<'_>,
-        permissions: HashMap<AppID, Vec<Permission>>,
+        permissions: HashMap<MaybeAppID, Vec<Permission>>,
     ) -> zbus::Result<()> {
         self.document_changed(table, id, deleted, data, permissions)
             .await
@@ -154,7 +154,7 @@ impl PermissionStoreInterface {
         &self,
         table: &str,
         id: DocumentID,
-    ) -> Result<(HashMap<AppID, Vec<Permission>>, OwnedValue), PortalError> {
+    ) -> Result<(HashMap<MaybeAppID, Vec<Permission>>, OwnedValue), PortalError> {
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::Lookup");
 
@@ -170,7 +170,7 @@ impl PermissionStoreInterface {
         table: &str,
         create: bool,
         id: DocumentID,
-        app_permissions: HashMap<AppID, Vec<Permission>>,
+        app_permissions: HashMap<MaybeAppID, Vec<Permission>>,
         data: Value<'_>,
     ) -> Result<(), PortalError> {
         #[cfg(feature = "tracing")]
@@ -217,7 +217,7 @@ impl PermissionStoreInterface {
         &self,
         table: &str,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
     ) -> Result<Vec<Permission>, PortalError> {
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::GetPermission");
@@ -234,7 +234,7 @@ impl PermissionStoreInterface {
         table: &str,
         create: bool,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
         permissions: Vec<Permission>,
     ) -> Result<(), PortalError> {
         #[cfg(feature = "tracing")]
@@ -254,7 +254,7 @@ impl PermissionStoreInterface {
         &self,
         table: &str,
         id: DocumentID,
-        app: AppID,
+        app: MaybeAppID,
     ) -> Result<(), PortalError> {
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::DeletePermission");
@@ -284,6 +284,6 @@ impl PermissionStoreInterface {
         id: DocumentID,
         deleted: bool,
         data: Value<'_>,
-        permissions: HashMap<AppID, Vec<Permission>>,
+        permissions: HashMap<MaybeAppID, Vec<Permission>>,
     ) -> zbus::Result<()>;
 }

--- a/client/src/backend/print.rs
+++ b/client/src/backend/print.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -23,7 +23,7 @@ pub trait PrintImpl: RequestImpl {
     async fn prepare_print(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         parent_window: Option<WindowIdentifierType>,
         title: String,
         settings: Settings,
@@ -35,7 +35,7 @@ pub trait PrintImpl: RequestImpl {
     async fn print(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         parent_window: Option<WindowIdentifierType>,
         title: String,
         fd: zvariant::OwnedFd,
@@ -71,7 +71,7 @@ impl PrintInterface {
     async fn prepare_print(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         settings: Settings,
@@ -107,7 +107,7 @@ impl PrintInterface {
     async fn print(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         fd: zvariant::OwnedFd,

--- a/client/src/backend/screencast.rs
+++ b/client/src/backend/screencast.rs
@@ -5,7 +5,7 @@ use enumflags2::BitFlags;
 use serde::Serialize;
 
 use crate::{
-    AppID, PortalError, WindowIdentifierType,
+    MaybeAppID, PortalError, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -36,7 +36,7 @@ pub trait ScreencastImpl: RequestImpl + SessionImpl {
         &self,
         token: HandleToken,
         session_token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         options: CreateSessionOptions,
     ) -> Result<CreateSessionResponse>;
 
@@ -44,7 +44,7 @@ pub trait ScreencastImpl: RequestImpl + SessionImpl {
     async fn select_sources(
         &self,
         session_token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         options: SelectSourcesOptions,
     ) -> Result<SelectSourcesResponse>;
 
@@ -52,7 +52,7 @@ pub trait ScreencastImpl: RequestImpl + SessionImpl {
     async fn start_cast(
         &self,
         session_token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         options: StartCastOptions,
     ) -> Result<Streams>;
@@ -112,7 +112,7 @@ impl ScreencastInterface {
         &self,
         handle: OwnedObjectPath,
         session_handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         options: CreateSessionOptions,
     ) -> Result<Response<CreateSessionResponse>> {
         let session_token = HandleToken::try_from(&session_handle).unwrap();
@@ -178,7 +178,7 @@ impl ScreencastInterface {
         &self,
         handle: OwnedObjectPath,
         session_handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         options: SelectSourcesOptions,
     ) -> Result<Response<SelectSourcesResponse>> {
         let session_token = HandleToken::try_from(&session_handle).unwrap();
@@ -208,7 +208,7 @@ impl ScreencastInterface {
         &self,
         handle: OwnedObjectPath,
         session_handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: StartCastOptions,
     ) -> Result<Response<Streams>> {

--- a/client/src/backend/screenshot.rs
+++ b/client/src/backend/screenshot.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -22,7 +22,7 @@ pub trait ScreenshotImpl: RequestImpl {
     async fn screenshot(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         options: ScreenshotOptions,
     ) -> Result<ScreenshotResponse>;
@@ -31,7 +31,7 @@ pub trait ScreenshotImpl: RequestImpl {
     async fn pick_color(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         options: ColorOptions,
     ) -> Result<Color>;
@@ -65,7 +65,7 @@ impl ScreenshotInterface {
     async fn screenshot(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: ScreenshotOptions,
     ) -> Result<Response<ScreenshotResponse>> {
@@ -95,7 +95,7 @@ impl ScreenshotInterface {
     async fn pick_color(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: ColorOptions,
     ) -> Result<Response<Color>> {

--- a/client/src/backend/secret.rs
+++ b/client/src/backend/secret.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use zbus::zvariant::{self, OwnedValue};
 
 use crate::{
-    AppID,
+    MaybeAppID,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -18,7 +18,7 @@ pub trait SecretImpl: RequestImpl {
     async fn retrieve(
         &self,
         token: HandleToken,
-        app_id: AppID,
+        app_id: MaybeAppID,
         fd: std::os::fd::OwnedFd,
     ) -> Result<HashMap<String, OwnedValue>>;
 }
@@ -50,7 +50,7 @@ impl SecretInterface {
     async fn retrieve_secret(
         &self,
         handle: zvariant::OwnedObjectPath,
-        app_id: AppID,
+        app_id: MaybeAppID,
         fd: zvariant::OwnedFd,
         _options: HashMap<String, OwnedValue>,
     ) -> Result<Response<HashMap<String, OwnedValue>>> {

--- a/client/src/backend/usb.rs
+++ b/client/src/backend/usb.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -43,7 +43,7 @@ pub trait UsbImpl: RequestImpl {
         &self,
         token: HandleToken,
         window_identifier: Option<WindowIdentifierType>,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         devices: Vec<(String, UsbDevice, AccessOptions)>,
         options: AcquireDevicesOptions,
     ) -> Result<Vec<(String, AccessOptions)>>;
@@ -78,7 +78,7 @@ impl UsbInterface {
         &self,
         handle: OwnedObjectPath,
         window_identifier: Optional<WindowIdentifierType>,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         devices: Vec<(String, UsbDevice, AccessOptions)>,
         options: AcquireDevicesOptions,
     ) -> Result<Response<Vec<(String, AccessOptions)>>> {

--- a/client/src/backend/wallpaper.rs
+++ b/client/src/backend/wallpaper.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    AppID, Uri, WindowIdentifierType,
+    MaybeAppID, Uri, WindowIdentifierType,
     backend::{
         Result,
         request::{Request, RequestImpl},
@@ -18,7 +18,7 @@ pub trait WallpaperImpl: RequestImpl {
     async fn with_uri(
         &self,
         token: HandleToken,
-        app_id: Option<AppID>,
+        app_id: Option<MaybeAppID>,
         window_identifier: Option<WindowIdentifierType>,
         uri: Uri,
         options: WallpaperOptions,
@@ -53,7 +53,7 @@ impl WallpaperInterface {
     async fn set_wallpaper_uri(
         &self,
         handle: OwnedObjectPath,
-        app_id: Optional<AppID>,
+        app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         uri: Uri,
         options: WallpaperOptions,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -31,6 +31,8 @@ pub use self::{activation_token::ActivationToken, window_identifier::WindowIdent
 mod app_id;
 mod registry;
 mod uri;
+#[cfg(feature = "backend")]
+pub use self::app_id::MaybeAppID;
 pub use self::{
     app_id::AppID,
     registry::{register_host_app, register_host_app_with_connection},

--- a/demo/backend/src/access.rs
+++ b/demo/backend/src/access.rs
@@ -1,5 +1,5 @@
 use ashpd::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         access::{AccessImpl, AccessOptions, AccessResponse},
@@ -24,7 +24,7 @@ impl AccessImpl for Access {
     async fn access_dialog(
         &self,
         _handle: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _title: String,
         _subtitle: String,

--- a/demo/backend/src/account.rs
+++ b/demo/backend/src/account.rs
@@ -1,5 +1,5 @@
 use ashpd::{
-    AppID, Uri, WindowIdentifierType,
+    MaybeAppID, Uri, WindowIdentifierType,
     backend::{Result, account::AccountImpl, request::RequestImpl},
     desktop::{
         HandleToken,
@@ -39,7 +39,7 @@ impl AccountImpl for Account {
     async fn get_user_information(
         &self,
         _token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: UserInformationOptions,
     ) -> Result<UserInformation> {

--- a/demo/backend/src/screencast.rs
+++ b/demo/backend/src/screencast.rs
@@ -1,5 +1,5 @@
 use ashpd::{
-    AppID, WindowIdentifierType,
+    MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
         request::RequestImpl,
@@ -41,7 +41,7 @@ impl ScreencastImpl for Screencast {
         &self,
         _token: HandleToken,
         session_token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _options: CreateSessionOptions,
     ) -> Result<CreateSessionResponse> {
         tracing::debug!("IN Screencast::create_session(): {session_token}");
@@ -51,7 +51,7 @@ impl ScreencastImpl for Screencast {
     async fn select_sources(
         &self,
         session_token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _options: SelectSourcesOptions,
     ) -> Result<SelectSourcesResponse> {
         tracing::debug!("IN Screencast::select_sources(): {session_token}");
@@ -61,7 +61,7 @@ impl ScreencastImpl for Screencast {
     async fn start_cast(
         &self,
         session_token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: StartCastOptions,
     ) -> Result<Streams> {

--- a/demo/backend/src/screenshot.rs
+++ b/demo/backend/src/screenshot.rs
@@ -1,5 +1,5 @@
 use ashpd::{
-    AppID, Uri, WindowIdentifierType,
+    MaybeAppID, Uri, WindowIdentifierType,
     backend::{Result, request::RequestImpl, screenshot::ScreenshotImpl},
     desktop::{
         Color, HandleToken,
@@ -23,7 +23,7 @@ impl ScreenshotImpl for Screenshot {
     async fn screenshot(
         &self,
         _token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: ScreenshotOptions,
     ) -> Result<ScreenshotResponse> {
@@ -35,7 +35,7 @@ impl ScreenshotImpl for Screenshot {
     async fn pick_color(
         &self,
         _token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _options: ColorOptions,
     ) -> Result<Color> {

--- a/demo/backend/src/secret.rs
+++ b/demo/backend/src/secret.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ashpd::{
-    AppID,
+    MaybeAppID,
     backend::{Result, request::RequestImpl, secret::SecretImpl},
     desktop::HandleToken,
     zbus::zvariant::OwnedValue,
@@ -23,7 +23,7 @@ impl SecretImpl for Secret {
     async fn retrieve(
         &self,
         _token: HandleToken,
-        _app_id: AppID,
+        _app_id: MaybeAppID,
         _fd: std::os::fd::OwnedFd,
     ) -> Result<HashMap<String, OwnedValue>> {
         Ok(Default::default())

--- a/demo/backend/src/wallpaper.rs
+++ b/demo/backend/src/wallpaper.rs
@@ -1,5 +1,5 @@
 use ashpd::{
-    AppID, Uri, WindowIdentifierType,
+    MaybeAppID, Uri, WindowIdentifierType,
     backend::{Result, request::RequestImpl, wallpaper::WallpaperImpl},
     desktop::{HandleToken, wallpaper::WallpaperOptions},
 };
@@ -20,7 +20,7 @@ impl WallpaperImpl for Wallpaper {
     async fn with_uri(
         &self,
         _token: HandleToken,
-        _app_id: Option<AppID>,
+        _app_id: Option<MaybeAppID>,
         _window_identifier: Option<WindowIdentifierType>,
         _uri: Uri,
         _options: WallpaperOptions,


### PR DESCRIPTION
`AppID` is strict in accepting only valid application IDs. So requests from apps like Firefox (which has the ID `firefox`) will fail with `Invalid app ID` error.

So let us use `DesktopID` to indicate this scenario.

Closes: https://github.com/bilelmoussaoui/ashpd/issues/432