### PR TITLE
Add German translation

### DIFF
--- a/demo/client/po/LINGUAS
+++ b/demo/client/po/LINGUAS
@@ -1,3 +1,4 @@
+de
 ka
 kk
 pt

--- a/demo/client/po/de.po
+++ b/demo/client/po/de.po
@@ -1,0 +1,176 @@
+# German translation for ashpd.
+# Copyright (C) 2026 ashpd's COPYRIGHT HOLDER
+# This file is distributed under the same license as the ashpd package.
+# Christian Kirbach <christian.kirbach@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ashpd main\n"
+"Report-Msgid-Bugs-To: https://github.com/bilelmoussaoui/ashpd/issues\n"
+"POT-Creation-Date: 2026-05-01 15:24+0000\n"
+"PO-Revision-Date: 2026-05-01 23:27+0200\n"
+"Last-Translator: Christian Kirbach <christian.kirbach@gmail.com>\n"
+"Language-Team: German <German>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: ../src/main.rs:40
+msgid "ASHPD Demo"
+msgstr "ASHPD-Demo"
+
+#: ../src/portals/desktop/file_chooser.rs:132
+msgid "Choice ID"
+msgstr ""
+
+#: ../src/portals/desktop/file_chooser.rs:135
+#: ../src/portals/desktop/notification.rs:446
+msgid "Label"
+msgstr "Beschriftung"
+
+#: ../src/portals/desktop/file_chooser.rs:138
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/portals/desktop/file_chooser.rs:140
+msgid "Boolean"
+msgstr "Boolescher Wert"
+
+#: ../src/portals/desktop/file_chooser.rs:141
+msgid "Dropdown"
+msgstr ""
+
+#: ../src/portals/desktop/file_chooser.rs:154
+msgid "Initial State"
+msgstr "Ausgangszustand"
+
+#: ../src/portals/desktop/file_chooser.rs:158
+msgid "Initial Selection"
+msgstr "Anfangsauswahl"
+
+#: ../src/portals/desktop/file_chooser.rs:167
+msgid "Options"
+msgstr "Optionen"
+
+#: ../src/portals/desktop/file_chooser.rs:168
+msgid "One option per line: key=value"
+msgstr ""
+
+#: ../src/portals/desktop/file_chooser.rs:206
+#: ../src/portals/desktop/notification.rs:472
+msgid "Remove"
+msgstr "Entfernen"
+
+#: ../src/portals/desktop/file_chooser.rs:338
+msgid "File Encoding"
+msgstr ""
+
+#: ../src/portals/desktop/file_chooser.rs:355
+msgid "Compress File"
+msgstr "Datei komprimieren"
+
+#: ../src/portals/desktop/file_chooser.rs:373
+msgid "Create Archive"
+msgstr "Archiv anlegen"
+
+#: ../src/portals/desktop/file_chooser.rs:456
+msgid "Text files"
+msgstr "Textdateien"
+
+#: ../src/portals/desktop/file_chooser.rs:462
+#: ../src/portals/desktop/wallpaper.rs:81
+msgid "Images"
+msgstr "Bilder"
+
+#: ../src/portals/desktop/file_chooser.rs:465
+msgid "Videos"
+msgstr "Videos"
+
+#: ../src/portals/desktop/notification.rs:112
+msgid "View"
+msgstr "Ansicht"
+
+#: ../src/portals/desktop/notification.rs:125
+msgid "Dismiss"
+msgstr "Verwerfen"
+
+#: ../src/portals/desktop/notification.rs:177
+msgid "Audio files"
+msgstr "Audiodateien"
+
+#: ../src/portals/desktop/notification.rs:184
+#: ../src/portals/desktop/wallpaper.rs:88
+msgid "Select"
+msgstr "Auswählen"
+
+#: ../src/portals/desktop/notification.rs:186
+msgid "Notification Sound"
+msgstr "Benachrichtigungston"
+
+#: ../src/portals/desktop/notification.rs:324
+msgid "Notification sent"
+msgstr "Benachrichtigung gesendet"
+
+#: ../src/portals/desktop/notification.rs:448
+msgid "Action"
+msgstr "Aktion"
+
+#: ../src/portals/desktop/notification.rs:450
+msgid "Action Target"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:453
+msgid "Purpose"
+msgstr "Zweck"
+
+#: ../src/portals/desktop/notification.rs:455
+msgid "None"
+msgstr "Keiner"
+
+#: ../src/portals/desktop/notification.rs:456
+msgid "IM Reply with Text"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:457
+msgid "Call Accept"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:458
+msgid "Call Decline"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:459
+msgid "Call Hang Up"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:460
+msgid "Call Enable Speakerphone"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:461
+msgid "Call Disable Speakerphone"
+msgstr ""
+
+#: ../src/portals/desktop/notification.rs:462
+msgid "System Custom Alert"
+msgstr ""
+
+#: ../src/portals/desktop/settings.rs:136
+msgid "Enabled"
+msgstr "Eingeschaltet"
+
+#: ../src/portals/desktop/settings.rs:138
+msgid "Disabled"
+msgstr "Ausgeschaltet"
+
+#: ../src/update_window.rs:117
+msgid "Starting update…"
+msgstr ""
+
+#: ../src/update_window.rs:181
+#, rust-format
+msgid "Operation {} of {}"
+msgstr "Operation {} of {}"


### PR DESCRIPTION
Add translation in German from Damned Lies: https://l10n.gnome.org/vertimus/7475/1816/18/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.