### PR TITLE
handletoken: fix panic when handle token starts with a digit

### DIFF
--- a/client/src/desktop/handle_token.rs
+++ b/client/src/desktop/handle_token.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use zbus::{names::OwnedMemberName, zvariant::Type};
+use zbus::zvariant::Type;
 
 /// A handle token is a DBus Object Path element.
 ///
@@ -16,7 +16,7 @@ use zbus::{names::OwnedMemberName, zvariant::Type};
 /// A valid object path element must only contain the ASCII characters
 /// `[A-Z][a-z][0-9]_`
 #[derive(Serialize, Type, PartialEq, Eq, Hash, Clone)]
-pub struct HandleToken(OwnedMemberName);
+pub struct HandleToken(String);
 
 impl Display for HandleToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -48,7 +48,7 @@ impl Default for HandleToken {
             token.push(ALPHANUMERIC[idx] as char);
         }
 
-        Self(OwnedMemberName::try_from(token).unwrap())
+        Self(token)
     }
 }
 
@@ -67,12 +67,18 @@ impl std::str::FromStr for HandleToken {
     type Err = HandleInvalidCharacter;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() {
+            // Temporary value for backward compatibility
+            return Err(HandleInvalidCharacter('\0'));
+        }
+
         for char in value.chars() {
             if !char.is_ascii_alphanumeric() && char != '_' {
                 return Err(HandleInvalidCharacter(char));
             }
         }
-        Ok(Self(OwnedMemberName::try_from(value).unwrap()))
+
+        Ok(Self(value.to_string()))
     }
 }
 
@@ -102,7 +108,7 @@ impl TryFrom<&zbus::zvariant::OwnedObjectPath> for HandleToken {
             .split('/')
             .next_back()
             .expect("A valid request ObjectPath");
-        HandleToken::try_from(base_segment)
+        Self::try_from(base_segment)
     }
 }
 
@@ -130,11 +136,15 @@ mod test {
         let token = HandleToken::from_str("token2").unwrap();
         assert_eq!(token.to_string(), "token2".to_string());
 
+        assert!(HandleToken::from_str("2token").is_ok());
+
         assert!(HandleToken::from_str("/test").is_err());
 
         assert!(HandleToken::from_str("تجربة").is_err());
 
         assert!(HandleToken::from_str("test_token").is_ok());
+
+        assert!(HandleToken::from_str("").is_err());
 
         HandleToken::default(); // ensure we don't panic
     }

--- a/client/src/desktop/handle_token.rs
+++ b/client/src/desktop/handle_token.rs
@@ -53,28 +53,33 @@ impl Default for HandleToken {
 }
 
 #[derive(Debug)]
-pub struct HandleInvalidCharacter(char);
+pub enum HandleTokenParseError {
+    InvalidCharacter(char),
+    Empty,
+}
 
-impl std::fmt::Display for HandleInvalidCharacter {
+impl std::fmt::Display for HandleTokenParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("Invalid Character {}", self.0))
+        match self {
+            Self::InvalidCharacter(c) => f.write_fmt(format_args!("Invalid Character {c}")),
+            Self::Empty => f.write_str("Empty HandleToken"),
+        }
     }
 }
 
-impl std::error::Error for HandleInvalidCharacter {}
+impl std::error::Error for HandleTokenParseError {}
 
 impl std::str::FromStr for HandleToken {
-    type Err = HandleInvalidCharacter;
+    type Err = HandleTokenParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         if value.is_empty() {
-            // Temporary value for backward compatibility
-            return Err(HandleInvalidCharacter('\0'));
+            return Err(HandleTokenParseError::Empty);
         }
 
         for char in value.chars() {
             if !char.is_ascii_alphanumeric() && char != '_' {
-                return Err(HandleInvalidCharacter(char));
+                return Err(HandleTokenParseError::InvalidCharacter(char));
             }
         }
 
@@ -83,7 +88,7 @@ impl std::str::FromStr for HandleToken {
 }
 
 impl TryFrom<String> for HandleToken {
-    type Error = HandleInvalidCharacter;
+    type Error = HandleTokenParseError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         value.parse::<Self>()
@@ -91,7 +96,7 @@ impl TryFrom<String> for HandleToken {
 }
 
 impl TryFrom<&str> for HandleToken {
-    type Error = HandleInvalidCharacter;
+    type Error = HandleTokenParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         value.parse::<Self>()
@@ -100,7 +105,7 @@ impl TryFrom<&str> for HandleToken {
 
 #[cfg(feature = "backend")]
 impl TryFrom<&zbus::zvariant::OwnedObjectPath> for HandleToken {
-    type Error = HandleInvalidCharacter;
+    type Error = HandleTokenParseError;
 
     fn try_from(value: &zbus::zvariant::OwnedObjectPath) -> Result<Self, Self::Error> {
         let base_segment = value


### PR DESCRIPTION
HandleTokens fail to parse if they start with a digit. The code assumes a handle token is a valid member name, but it's only the last segment from an object path, so it's allowed to start with a digit.

I was getting panics when trying to handle requests from flatpak applications that sent requests with object paths like "/org/freedesktop/portal/desktop/request/1_4046/739A6188BA0E1B1913FFDCCB3165B7D1".

The handle token was "739A6188BA0E1B1913FFDCCB3165B7D17DDFDC01", and that's valid, but ashpd would panic.

```
owned member name /org/freedesktop/portal/desktop/request/1_4046/739A6188BA0E1B1913FFDCCB3165B7D
parsing handle token 739A6188BA0E1B1913FFDCCB3165B7D1
called `Result::unwrap()` on an `Err` value: InvalidName("Invalid member name. See https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member")
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:80:14
   2: core::result::unwrap_failed
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/result.rs:1867:5
   3: core::result::Result<T,E>::unwrap
             at /home/desuwa/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1233:23
   4: <ashpd::desktop::handle_token::HandleToken as core::str::traits::FromStr>::from_str
             at /storage/src/third_party/ashpd/client/src/desktop/handle_token.rs:88:50
   5: core::str::<impl str>::parse
             at /home/desuwa/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/str/mod.rs:2762:9
   6: <ashpd::desktop::handle_token::HandleToken as core::convert::TryFrom<&str>>::try_from
             at /storage/src/third_party/ashpd/client/src/desktop/handle_token.rs:104:15
   7: <ashpd::desktop::handle_token::HandleToken as core::convert::TryFrom<&zvariant::object_path::OwnedObjectPath>>::try_from
             at /storage/src/third_party/ashpd/client/src/desktop/handle_token.rs:118:9
...
```

edit: member name -> object path