### PR TITLE
build(deps): bump quick-xml from 0.40.1 to 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
  "gstreamer",
  "gtk4",
  "pipewire",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "raw-window-handle",
  "reis",
  "serde",
@@ -1819,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -99,7 +99,7 @@ reis = { version = "0.7", features = ["tokio"] }
 pipewire = "0.10.0"
 tokio = { version = "1.51", features = [ "rt-multi-thread", "macros" ] }
 gst = { package = "gstreamer", version = "0.25" }
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 [package.metadata.docs.rs]
 features = ["backend", "gtk4", "raw_handle",


### PR DESCRIPTION
This addresses two RUSTSEC advisories

https://rustsec.org/advisories/RUSTSEC-2026-0194.html
https://rustsec.org/advisories/RUSTSEC-2026-0195.html

although the impact is low since this is only a dev-dependency.