### PR TITLE
backend: authenticate portal frontend callers

### DIFF
--- a/client/src/backend/access.rs
+++ b/client/src/backend/access.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{HandleToken, Icon, request::Response},
@@ -117,6 +119,7 @@ pub(crate) struct AccessInterface {
     imp: Arc<dyn AccessImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl AccessInterface {
@@ -124,8 +127,14 @@ impl AccessInterface {
         imp: Arc<dyn AccessImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -147,12 +156,17 @@ impl AccessInterface {
         subtitle: String,
         body: String,
         options: AccessOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<AccessResponse>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Access::AccessDialog",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/account.rs
+++ b/client/src/backend/account.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{
@@ -32,6 +34,7 @@ pub(crate) struct AccountInterface {
     imp: Arc<dyn AccountImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl AccountInterface {
@@ -39,8 +42,14 @@ impl AccountInterface {
         imp: Arc<dyn AccountImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -59,12 +68,17 @@ impl AccountInterface {
         app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: UserInformationOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<UserInformation>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Account::GetUserInformation",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/app_chooser.rs
+++ b/client/src/backend/app_chooser.rs
@@ -2,10 +2,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use zbus::message::Header;
 
 use crate::{
     ActivationToken, MaybeAppID, PortalError, Uri, WindowIdentifierType,
-    backend::request::{Request, RequestImpl},
+    backend::{
+        caller::CallerAuthorization,
+        request::{Request, RequestImpl},
+    },
     desktop::{HandleToken, Response},
     zvariant::{
         Optional, OwnedObjectPath, Type,
@@ -107,6 +111,7 @@ pub(crate) struct AppChooserInterface {
     imp: Arc<dyn AppChooserImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl AppChooserInterface {
@@ -114,8 +119,14 @@ impl AppChooserInterface {
         imp: Arc<dyn AppChooserImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -134,12 +145,17 @@ impl AppChooserInterface {
         parent_window: Optional<WindowIdentifierType>,
         choices: Vec<MaybeAppID>,
         options: ChooserOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<Choice>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "AppChooser::ChooseApplication",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -161,7 +177,11 @@ impl AppChooserInterface {
         &self,
         handle: OwnedObjectPath,
         choices: Vec<MaybeAppID>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("AppChooser::UpdateChoices");
 

--- a/client/src/backend/background.rs
+++ b/client/src/backend/background.rs
@@ -4,10 +4,14 @@ use async_trait::async_trait;
 use enumflags2::{BitFlags, bitflags};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, PortalError,
-    backend::request::{Request, RequestImpl},
+    backend::{
+        caller::CallerAuthorization,
+        request::{Request, RequestImpl},
+    },
     desktop::{HandleToken, Response},
     zbus::object_server::SignalEmitter,
     zvariant::{OwnedObjectPath, Type, as_value},
@@ -85,6 +89,7 @@ pub(crate) struct BackgroundInterface {
     imp: Arc<dyn BackgroundImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl BackgroundInterface {
@@ -92,8 +97,14 @@ impl BackgroundInterface {
         imp: Arc<dyn BackgroundImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 
     pub async fn changed(&self) -> zbus::Result<()> {
@@ -120,7 +131,13 @@ impl BackgroundInterface {
     }
 
     #[zbus(out_args("apps"))]
-    async fn get_app_state(&self) -> Result<HashMap<MaybeAppID, AppState>, PortalError> {
+    async fn get_app_state(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+    ) -> Result<HashMap<MaybeAppID, AppState>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("Background::GetAppState");
 
@@ -137,12 +154,17 @@ impl BackgroundInterface {
         handle: OwnedObjectPath,
         app_id: MaybeAppID,
         name: String,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<Background>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Background::NotifyBackground",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -161,7 +183,11 @@ impl BackgroundInterface {
         enable: bool,
         commandline: Vec<String>,
         flags: BitFlags<AutoStartFlags>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<bool, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("Background::EnableAutostart");
 

--- a/client/src/backend/builder.rs
+++ b/client/src/backend/builder.rs
@@ -4,11 +4,18 @@ use enumflags2::BitFlags;
 use futures_util::{StreamExt, task::SpawnExt};
 use zbus::names::{OwnedWellKnownName, WellKnownName};
 
-use crate::backend::{Result, session::SessionManager};
+use crate::{
+    backend::{Result, caller::CallerAuthorization, session::SessionManager},
+    proxy::DESKTOP_DESTINATION,
+};
 
 pub struct Builder {
     name: OwnedWellKnownName,
     flags: BitFlags<zbus::fdo::RequestNameFlags>,
+    caller_authorization: CallerAuthorization,
+    lockdown_caller_authorization: Option<CallerAuthorization>,
+    #[cfg(feature = "documents")]
+    permission_store_caller_authorization: CallerAuthorization,
     #[cfg(feature = "account")]
     account_impl: Option<Arc<dyn crate::backend::account::AccountImpl>>,
     access_impl: Option<Arc<dyn crate::backend::access::AccessImpl>>,
@@ -53,6 +60,11 @@ impl Builder {
             // same flags as zbus::Connection::request_name
             flags: zbus::fdo::RequestNameFlags::ReplaceExisting
                 | zbus::fdo::RequestNameFlags::DoNotQueue,
+            caller_authorization: CallerAuthorization::require_name(DESKTOP_DESTINATION)
+                .expect("valid portal frontend bus name"),
+            lockdown_caller_authorization: None,
+            #[cfg(feature = "documents")]
+            permission_store_caller_authorization: CallerAuthorization::allow_all(),
             #[cfg(feature = "account")]
             account_impl: None,
             access_impl: None,
@@ -103,6 +115,43 @@ impl Builder {
 
     pub fn with_name_lost(mut self, name_lost: impl Fn() + Send + Sync + 'static) -> Self {
         self.name_lost = Some(Arc::new(name_lost));
+        self
+    }
+
+    /// Set the caller policy for frontend-facing portal interfaces.
+    ///
+    /// By default, only the current owner of
+    /// `org.freedesktop.portal.Desktop` is allowed. Lockdown inherits this
+    /// policy unless overridden with
+    /// [`Self::with_lockdown_caller_authorization`].
+    pub fn with_caller_authorization(mut self, authorization: CallerAuthorization) -> Self {
+        self.caller_authorization = authorization;
+        self
+    }
+
+    /// Set the caller policy for the Lockdown backend interface.
+    ///
+    /// Lockdown can be shared by multiple portal frontends. By default it
+    /// inherits the frontend-facing policy.
+    pub fn with_lockdown_caller_authorization(
+        mut self,
+        authorization: CallerAuthorization,
+    ) -> Self {
+        self.lockdown_caller_authorization = Some(authorization);
+        self
+    }
+
+    /// Set the caller policy for the PermissionStore backend interface.
+    ///
+    /// PermissionStore has legitimate callers outside the portal frontend,
+    /// including the document portal and PipeWire's permission manager. It
+    /// therefore allows all callers by default.
+    #[cfg(feature = "documents")]
+    pub fn with_permission_store_caller_authorization(
+        mut self,
+        authorization: CallerAuthorization,
+    ) -> Self {
+        self.permission_store_caller_authorization = authorization;
         self
     }
 
@@ -241,12 +290,21 @@ impl Builder {
         }
 
         let object_server = connection.object_server();
+        let caller_authorization = Arc::new(self.caller_authorization);
+        let lockdown_caller_authorization = Arc::new(
+            self.lockdown_caller_authorization
+                .unwrap_or_else(|| (*caller_authorization).clone()),
+        );
+        #[cfg(feature = "documents")]
+        let permission_store_caller_authorization =
+            Arc::new(self.permission_store_caller_authorization);
         #[cfg(feature = "account")]
         if let Some(imp) = self.account_impl {
             let portal = crate::backend::account::AccountInterface::new(
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Account`");
@@ -260,6 +318,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Access`");
@@ -273,6 +332,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.AppChooser`");
@@ -287,6 +347,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Background`");
@@ -301,6 +362,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Email`");
@@ -315,6 +377,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.FileChooser`");
@@ -328,6 +391,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&lockdown_caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Lockdown`");
@@ -342,6 +406,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&permission_store_caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.PermissionStore`");
@@ -356,6 +421,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Print`");
@@ -371,6 +437,7 @@ impl Builder {
                 connection.clone(),
                 Arc::clone(&spawn),
                 Arc::clone(&self.sessions),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.ScreenCast`");
@@ -385,6 +452,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Screenshot`");
@@ -399,6 +467,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Secret`");
@@ -413,6 +482,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Settings`");
@@ -427,6 +497,7 @@ impl Builder {
                 imp,
                 connection.clone(),
                 Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
             );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Wallpaper`");
@@ -437,8 +508,12 @@ impl Builder {
 
         #[cfg(feature = "usb")]
         if let Some(imp) = self.usb_impl {
-            let portal =
-                crate::backend::usb::UsbInterface::new(imp, connection.clone(), Arc::clone(&spawn));
+            let portal = crate::backend::usb::UsbInterface::new(
+                imp,
+                connection.clone(),
+                Arc::clone(&spawn),
+                Arc::clone(&caller_authorization),
+            );
             #[cfg(feature = "tracing")]
             tracing::debug!("Serving interface `org.freedesktop.impl.portal.Usb`");
             object_server

--- a/client/src/backend/caller.rs
+++ b/client/src/backend/caller.rs
@@ -1,0 +1,136 @@
+use zbus::{
+    message::Header,
+    names::{BusName, OwnedWellKnownName, WellKnownName},
+};
+
+use crate::{PortalError, backend::Result};
+
+/// Controls which D-Bus peers may call a portal backend interface.
+#[derive(Clone, Debug)]
+pub struct CallerAuthorization {
+    allowed_names: Option<Vec<OwnedWellKnownName>>,
+}
+
+impl CallerAuthorization {
+    /// Allow calls from any D-Bus peer.
+    pub fn allow_all() -> Self {
+        Self {
+            allowed_names: None,
+        }
+    }
+
+    /// Only allow the current owner of `well_known_name`.
+    pub fn require_name<'a, W>(well_known_name: W) -> zbus::Result<Self>
+    where
+        W: TryInto<WellKnownName<'a>>,
+        <W as TryInto<WellKnownName<'a>>>::Error: Into<zbus::Error>,
+    {
+        Self::require_names([well_known_name])
+    }
+
+    /// Only allow the current owner of one of `well_known_names`.
+    pub fn require_names<'a, I, W>(well_known_names: I) -> zbus::Result<Self>
+    where
+        I: IntoIterator<Item = W>,
+        W: TryInto<WellKnownName<'a>>,
+        <W as TryInto<WellKnownName<'a>>>::Error: Into<zbus::Error>,
+    {
+        let allowed_names = well_known_names
+            .into_iter()
+            .map(|name| {
+                name.try_into()
+                    .map(OwnedWellKnownName::from)
+                    .map_err(Into::into)
+            })
+            .collect::<zbus::Result<_>>()?;
+
+        Ok(Self {
+            allowed_names: Some(allowed_names),
+        })
+    }
+
+    pub(crate) async fn authorize(
+        &self,
+        connection: &zbus::Connection,
+        header: &Header<'_>,
+    ) -> Result<()> {
+        let Some(allowed_names) = &self.allowed_names else {
+            return Ok(());
+        };
+        let sender = header.sender().ok_or_else(not_allowed)?;
+        let proxy = zbus::fdo::DBusProxy::new(connection).await?;
+
+        for name in allowed_names {
+            if proxy
+                .get_name_owner(BusName::from(name))
+                .await
+                .is_ok_and(|owner| sender_matches_owner(Some(sender.as_str()), owner.as_str()))
+            {
+                return Ok(());
+            }
+        }
+
+        Err(not_allowed())
+    }
+
+    pub(crate) async fn authorize_fdo(
+        &self,
+        connection: &zbus::Connection,
+        header: &Header<'_>,
+    ) -> zbus::fdo::Result<()> {
+        self.authorize(connection, header)
+            .await
+            .map_err(|error| zbus::fdo::Error::AccessDenied(error.to_string()))
+    }
+
+    pub(crate) async fn authorize_property(
+        &self,
+        connection: &zbus::Connection,
+        header: Option<&Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        let Some(header) = header else {
+            // Generated property-changed helpers invoke getters internally.
+            return Ok(());
+        };
+
+        self.authorize_fdo(connection, header).await
+    }
+}
+
+fn not_allowed() -> PortalError {
+    PortalError::NotAllowed("caller is not authorized to invoke this portal backend".into())
+}
+
+fn sender_matches_owner(sender: Option<&str>, owner: &str) -> bool {
+    sender == Some(owner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructs_single_and_multiple_name_policies() {
+        let one = CallerAuthorization::require_name("org.freedesktop.portal.Desktop").unwrap();
+        assert_eq!(one.allowed_names.unwrap().len(), 1);
+
+        let multiple = CallerAuthorization::require_names([
+            "org.freedesktop.portal.Desktop",
+            "org.freedesktop.portal.Documents",
+        ])
+        .unwrap();
+        assert_eq!(multiple.allowed_names.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn rejects_invalid_well_known_names() {
+        assert!(CallerAuthorization::require_name(":1.42").is_err());
+    }
+
+    #[test]
+    fn matches_only_the_current_unique_name() {
+        assert!(sender_matches_owner(Some(":1.42"), ":1.42"));
+        assert!(!sender_matches_owner(Some(":1.7"), ":1.42"));
+        assert!(!sender_matches_owner(None, ":1.42"));
+    }
+}

--- a/client/src/backend/email.rs
+++ b/client/src/backend/email.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{HandleToken, email::EmailOptions, request::Response},
@@ -28,6 +30,7 @@ pub(crate) struct EmailInterface {
     imp: Arc<dyn EmailImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl EmailInterface {
@@ -35,8 +38,14 @@ impl EmailInterface {
         imp: Arc<dyn EmailImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -54,12 +63,17 @@ impl EmailInterface {
         app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: EmailOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<()>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Email::ComposeEmail",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/file_chooser.rs
+++ b/client/src/backend/file_chooser.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{
@@ -53,6 +55,7 @@ pub(crate) struct FileChooserInterface {
     imp: Arc<dyn FileChooserImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl FileChooserInterface {
@@ -60,8 +63,14 @@ impl FileChooserInterface {
         imp: Arc<dyn FileChooserImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -80,12 +89,17 @@ impl FileChooserInterface {
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: OpenFileOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<SelectedFiles>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "FileChooser::OpenFile",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -111,12 +125,17 @@ impl FileChooserInterface {
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: SaveFileOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<SelectedFiles>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "FileChooser::SaveFile",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -142,12 +161,17 @@ impl FileChooserInterface {
         window_identifier: Optional<WindowIdentifierType>,
         title: String,
         options: SaveFilesOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<SelectedFiles>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "FileChooser::SaveFiles",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/lockdown.rs
+++ b/client/src/backend/lockdown.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
+
+use crate::backend::caller::CallerAuthorization;
 
 #[async_trait]
 pub trait LockdownImpl: Send + Sync {
@@ -49,6 +52,7 @@ pub(crate) struct LockdownInterface {
     cnx: zbus::Connection,
     #[allow(dead_code)]
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl LockdownInterface {
@@ -56,8 +60,14 @@ impl LockdownInterface {
         imp: Arc<dyn LockdownImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -69,12 +79,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-printing")]
-    async fn disable_printing(&self) -> bool {
-        self.imp.disable_printing().await
+    async fn disable_printing(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_printing().await)
     }
 
     #[zbus(property, name = "disable-printing")]
-    async fn set_disable_printing(&self, disable_printing: bool) -> zbus::Result<()> {
+    async fn set_disable_printing(
+        &self,
+        disable_printing: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -87,12 +110,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-save-to-disk")]
-    async fn disable_save_to_disk(&self) -> bool {
-        self.imp.disable_save_to_disk().await
+    async fn disable_save_to_disk(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_save_to_disk().await)
     }
 
     #[zbus(property, name = "disable-save-to-disk")]
-    async fn set_disable_save_to_disk(&self, disable_save_to_disk: bool) -> zbus::Result<()> {
+    async fn set_disable_save_to_disk(
+        &self,
+        disable_save_to_disk: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -107,15 +143,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-application-handlers")]
-    async fn disable_application_handlers(&self) -> bool {
-        self.imp.disable_application_handlers().await
+    async fn disable_application_handlers(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_application_handlers().await)
     }
 
     #[zbus(property, name = "disable-application-handlers")]
     async fn set_disable_application_handlers(
         &self,
         disable_application_handlers: bool,
-    ) -> zbus::Result<()> {
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -130,12 +176,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-location")]
-    async fn disable_location(&self) -> bool {
-        self.imp.disable_location().await
+    async fn disable_location(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_location().await)
     }
 
     #[zbus(property, name = "disable-location")]
-    async fn set_disable_location(&self, disable_location: bool) -> zbus::Result<()> {
+    async fn set_disable_location(
+        &self,
+        disable_location: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -148,12 +207,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-camera")]
-    async fn disable_camera(&self) -> bool {
-        self.imp.disable_camera().await
+    async fn disable_camera(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_camera().await)
     }
 
     #[zbus(property, name = "disable-camera")]
-    async fn set_disable_camera(&self, disable_camera: bool) -> zbus::Result<()> {
+    async fn set_disable_camera(
+        &self,
+        disable_camera: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -166,12 +238,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-microphone")]
-    async fn disable_microphone(&self) -> bool {
-        self.imp.disable_microphone().await
+    async fn disable_microphone(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_microphone().await)
     }
 
     #[zbus(property, name = "disable-microphone")]
-    async fn set_disable_microphone(&self, disable_microphone: bool) -> zbus::Result<()> {
+    async fn set_disable_microphone(
+        &self,
+        disable_microphone: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)
@@ -184,12 +269,25 @@ impl LockdownInterface {
     }
 
     #[zbus(property, name = "disable-sound-output")]
-    async fn disable_sound_output(&self) -> bool {
-        self.imp.disable_sound_output().await
+    async fn disable_sound_output(
+        &self,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<bool> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
+        Ok(self.imp.disable_sound_output().await)
     }
 
     #[zbus(property, name = "disable-sound-output")]
-    async fn set_disable_sound_output(&self, disable_sound_output: bool) -> zbus::Result<()> {
+    async fn set_disable_sound_output(
+        &self,
+        disable_sound_output: bool,
+        #[zbus(header)] header: Option<Header<'_>>,
+    ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_property(&self.cnx, header.as_ref())
+            .await?;
         let object_server = self.cnx.object_server();
         let iface_ref = object_server
             .interface::<_, Self>(crate::proxy::DESKTOP_PATH)

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -10,6 +10,8 @@ pub mod app_chooser;
 pub mod background;
 mod builder;
 pub use builder::Builder;
+mod caller;
+pub use caller::CallerAuthorization;
 #[cfg(feature = "email")]
 #[cfg_attr(docsrs, doc(cfg(feature = "email")))]
 pub mod email;

--- a/client/src/backend/permission_store.rs
+++ b/client/src/backend/permission_store.rs
@@ -1,9 +1,11 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, PortalError,
+    backend::caller::CallerAuthorization,
     documents::{DocumentID, Permission},
     zbus::object_server::SignalEmitter,
     zvariant::{OwnedValue, Value},
@@ -91,6 +93,7 @@ pub(crate) struct PermissionStoreInterface {
     cnx: zbus::Connection,
     #[allow(dead_code)]
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl PermissionStoreInterface {
@@ -98,8 +101,14 @@ impl PermissionStoreInterface {
         imp: Arc<dyn PermissionStoreImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 
     pub async fn document_changed(
@@ -154,7 +163,11 @@ impl PermissionStoreInterface {
         &self,
         table: &str,
         id: DocumentID,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(HashMap<MaybeAppID, Vec<Permission>>, OwnedValue), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::Lookup");
 
@@ -172,7 +185,11 @@ impl PermissionStoreInterface {
         id: DocumentID,
         app_permissions: HashMap<MaybeAppID, Vec<Permission>>,
         data: Value<'_>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::Set");
 
@@ -189,7 +206,11 @@ impl PermissionStoreInterface {
         create: bool,
         id: DocumentID,
         data: Value<'_>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::SetValue");
 
@@ -201,7 +222,14 @@ impl PermissionStoreInterface {
     }
 
     #[zbus(out_args("ids"))]
-    async fn list(&self, table: &str) -> Result<Vec<DocumentID>, PortalError> {
+    async fn list(
+        &self,
+        table: &str,
+        #[zbus(header)] header: Header<'_>,
+    ) -> Result<Vec<DocumentID>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::List");
 
@@ -218,7 +246,11 @@ impl PermissionStoreInterface {
         table: &str,
         id: DocumentID,
         app: MaybeAppID,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Vec<Permission>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::GetPermission");
 
@@ -236,7 +268,11 @@ impl PermissionStoreInterface {
         id: DocumentID,
         app: MaybeAppID,
         permissions: Vec<Permission>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::SetPermission");
 
@@ -255,7 +291,11 @@ impl PermissionStoreInterface {
         table: &str,
         id: DocumentID,
         app: MaybeAppID,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::DeletePermission");
 
@@ -266,7 +306,15 @@ impl PermissionStoreInterface {
         response
     }
 
-    async fn delete(&self, table: &str, id: DocumentID) -> Result<(), PortalError> {
+    async fn delete(
+        &self,
+        table: &str,
+        id: DocumentID,
+        #[zbus(header)] header: Header<'_>,
+    ) -> Result<(), PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("PermissionStore::Delete");
 

--- a/client/src/backend/print.rs
+++ b/client/src/backend/print.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{
@@ -47,6 +49,7 @@ pub(crate) struct PrintInterface {
     imp: Arc<dyn PrintImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl PrintInterface {
@@ -54,8 +57,14 @@ impl PrintInterface {
         imp: Arc<dyn PrintImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -77,12 +86,17 @@ impl PrintInterface {
         settings: Settings,
         page_setup: PageSetup,
         options: PreparePrintOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<PreparePrint>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Print::PreparePrint",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -112,12 +126,17 @@ impl PrintInterface {
         title: String,
         fd: zvariant::OwnedFd,
         options: PrintOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<()>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Print::Print",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/request.rs
+++ b/client/src/backend/request.rs
@@ -6,10 +6,12 @@ use futures_util::{
     lock::Mutex,
     task::SpawnExt,
 };
+use zbus::message::Header;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::{
     PortalError,
+    backend::caller::CallerAuthorization,
     desktop::{HandleToken, Response},
 };
 
@@ -25,6 +27,7 @@ pub struct Request {
     abort_handle: AbortHandle,
     #[allow(dead_code)]
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl Request {
@@ -35,6 +38,7 @@ impl Request {
     pub(crate) async fn spawn<T, R>(
         _method: &'static str,
         cnx: &zbus::Connection,
+        caller_authorization: Arc<CallerAuthorization>,
         path: OwnedObjectPath,
         imp: Arc<R>,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
@@ -57,7 +61,13 @@ impl Request {
                 let _ = err;
             }
         };
-        let request = Request::new(close_cb, path.clone(), abort_handle, cnx.clone());
+        let request = Request::new(
+            close_cb,
+            path.clone(),
+            abort_handle,
+            cnx.clone(),
+            caller_authorization,
+        );
         let server = cnx.object_server();
         #[cfg(feature = "tracing")]
         tracing::debug!(
@@ -94,12 +104,14 @@ impl Request {
         path: OwnedObjectPath,
         abort_handle: AbortHandle,
         cnx: zbus::Connection,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
         Self {
             close_cb: Mutex::new(Some(Box::new(close_cb))),
             path,
             abort_handle,
             cnx,
+            caller_authorization,
         }
     }
 }
@@ -116,7 +128,12 @@ impl Request {
     async fn close(
         &self,
         #[zbus(object_server)] server: &zbus::ObjectServer,
+        #[zbus(connection)] connection: &zbus::Connection,
+        #[zbus(header)] header: Header<'_>,
     ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_fdo(connection, &header)
+            .await?;
         self.abort_handle.abort();
         if let Some(close_cb) = self.close_cb.lock().await.take() {
             close_cb();

--- a/client/src/backend/screencast.rs
+++ b/client/src/backend/screencast.rs
@@ -3,11 +3,13 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use enumflags2::BitFlags;
 use serde::Serialize;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, PortalError, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
         session::{CreateSessionResponse, Session, SessionImpl, SessionManager},
     },
@@ -63,6 +65,7 @@ pub(crate) struct ScreencastInterface {
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
     sessions: Arc<Mutex<SessionManager>>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl ScreencastInterface {
@@ -71,12 +74,14 @@ impl ScreencastInterface {
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
         sessions: Arc<Mutex<SessionManager>>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
         Self {
             imp,
             cnx,
             spawn,
             sessions,
+            caller_authorization,
         }
     }
 }
@@ -114,7 +119,11 @@ impl ScreencastInterface {
         session_handle: OwnedObjectPath,
         app_id: Optional<MaybeAppID>,
         options: CreateSessionOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<CreateSessionResponse>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let session_token = HandleToken::try_from(&session_handle).unwrap();
         {
             let sessions = self.sessions.lock().unwrap();
@@ -131,6 +140,7 @@ impl ScreencastInterface {
         let result = Request::spawn(
             "ScreenCast::CreateSession",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -156,6 +166,7 @@ impl ScreencastInterface {
                 session_handle,
                 Arc::clone(&self.sessions),
                 Some(Arc::clone(&self.imp) as Arc<dyn SessionImpl>),
+                Arc::clone(&self.caller_authorization),
             );
             session.serve(self.cnx.clone()).await?;
             {
@@ -180,7 +191,11 @@ impl ScreencastInterface {
         session_handle: OwnedObjectPath,
         app_id: Optional<MaybeAppID>,
         options: SelectSourcesOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<SelectSourcesResponse>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let session_token = HandleToken::try_from(&session_handle).unwrap();
         {
             let sessions = self.sessions.lock().unwrap();
@@ -191,6 +206,7 @@ impl ScreencastInterface {
         Request::spawn(
             "ScreenCast::SelectSources",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -211,7 +227,11 @@ impl ScreencastInterface {
         app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: StartCastOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<Streams>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let session_token = HandleToken::try_from(&session_handle).unwrap();
         {
             let sessions = self.sessions.lock().unwrap();
@@ -222,6 +242,7 @@ impl ScreencastInterface {
         Request::spawn(
             "ScreenCast::Start",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/screenshot.rs
+++ b/client/src/backend/screenshot.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use enumflags2::BitFlags;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{
@@ -47,6 +49,7 @@ pub(crate) struct ScreenshotInterface {
     imp: Arc<dyn ScreenshotImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl ScreenshotInterface {
@@ -54,8 +57,14 @@ impl ScreenshotInterface {
         imp: Arc<dyn ScreenshotImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -79,12 +88,17 @@ impl ScreenshotInterface {
         app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: ScreenshotOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<ScreenshotResponse>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Screenshot::Screenshot",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),
@@ -109,12 +123,17 @@ impl ScreenshotInterface {
         app_id: Optional<MaybeAppID>,
         window_identifier: Optional<WindowIdentifierType>,
         options: ColorOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<Color>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Screenshot::PickColor",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/secret.rs
+++ b/client/src/backend/secret.rs
@@ -1,12 +1,16 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use zbus::zvariant::{self, OwnedValue};
+use zbus::{
+    message::Header,
+    zvariant::{self, OwnedValue},
+};
 
 use crate::{
     MaybeAppID,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{HandleToken, Response},
@@ -14,6 +18,10 @@ use crate::{
 
 #[async_trait]
 pub trait SecretImpl: RequestImpl {
+    /// Retrieve a secret for `app_id`.
+    ///
+    /// The D-Bus interface applies the caller authorization configured on
+    /// [`crate::backend::Builder`] before invoking this method.
     #[doc(alias = "RetrieveSecret")]
     async fn retrieve(
         &self,
@@ -27,6 +35,7 @@ pub(crate) struct SecretInterface {
     imp: Arc<dyn SecretImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl SecretInterface {
@@ -34,8 +43,14 @@ impl SecretInterface {
         imp: Arc<dyn SecretImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -53,12 +68,17 @@ impl SecretInterface {
         app_id: MaybeAppID,
         fd: zvariant::OwnedFd,
         _options: HashMap<String, OwnedValue>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<HashMap<String, OwnedValue>>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Secret::RetrieveSecret",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/session.rs
+++ b/client/src/backend/session.rs
@@ -6,16 +6,18 @@ use std::{
 use async_trait::async_trait;
 use serde::Serialize;
 use zbus::{
+    message::Header,
     object_server::SignalEmitter,
     zvariant::{OwnedObjectPath, Type, as_value},
 };
 
-use crate::{PortalError, desktop::HandleToken};
+use crate::{PortalError, backend::caller::CallerAuthorization, desktop::HandleToken};
 
 pub(crate) struct Session {
     path: OwnedObjectPath,
     manager: Arc<Mutex<SessionManager>>,
     monitor: Option<Arc<dyn SessionImpl>>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl Session {
@@ -23,11 +25,13 @@ impl Session {
         path: OwnedObjectPath,
         manager: Arc<Mutex<SessionManager>>,
         monitor: Option<Arc<dyn SessionImpl>>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
         Self {
             path,
             manager,
             monitor,
+            caller_authorization,
         }
     }
 
@@ -40,6 +44,7 @@ impl Session {
             self.path.clone(),
             Arc::clone(&self.manager),
             self.monitor.clone(),
+            Arc::clone(&self.caller_authorization),
         );
         cnx.object_server().at(&self.path, interface).await
     }
@@ -61,6 +66,7 @@ struct SessionInterface {
     path: OwnedObjectPath,
     manager: Arc<Mutex<SessionManager>>,
     monitor: Option<Arc<dyn SessionImpl>>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl SessionInterface {
@@ -68,11 +74,13 @@ impl SessionInterface {
         path: OwnedObjectPath,
         manager: Arc<Mutex<SessionManager>>,
         monitor: Option<Arc<dyn SessionImpl>>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
         Self {
             path,
             manager,
             monitor,
+            caller_authorization,
         }
     }
 }
@@ -88,7 +96,12 @@ impl SessionInterface {
     async fn close(
         &self,
         #[zbus(object_server)] server: &zbus::ObjectServer,
+        #[zbus(connection)] connection: &zbus::Connection,
+        #[zbus(header)] header: Header<'_>,
     ) -> zbus::fdo::Result<()> {
+        self.caller_authorization
+            .authorize_fdo(connection, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("SessionInterface::Close {}", self.path.as_str());
         let token = HandleToken::try_from(&self.path).unwrap();

--- a/client/src/backend/settings.rs
+++ b/client/src/backend/settings.rs
@@ -1,9 +1,11 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     PortalError,
+    backend::caller::CallerAuthorization,
     desktop::{
         Color,
         settings::{
@@ -44,6 +46,7 @@ pub(crate) struct SettingsInterface {
     cnx: zbus::Connection,
     #[allow(dead_code)]
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl SettingsInterface {
@@ -51,8 +54,14 @@ impl SettingsInterface {
         imp: Arc<dyn SettingsImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 
     pub async fn changed(&self, namespace: &str, key: &str, value: Value<'_>) -> zbus::Result<()> {
@@ -121,7 +130,11 @@ impl SettingsInterface {
     async fn read_all(
         &self,
         namespaces: Vec<String>,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<HashMap<String, Namespace>, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("Settings::ReadAll");
 
@@ -133,7 +146,15 @@ impl SettingsInterface {
     }
 
     #[zbus(out_args("value"))]
-    async fn read(&self, namespace: &str, key: &str) -> Result<OwnedValue, PortalError> {
+    async fn read(
+        &self,
+        namespace: &str,
+        key: &str,
+        #[zbus(header)] header: Header<'_>,
+    ) -> Result<OwnedValue, PortalError> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         #[cfg(feature = "tracing")]
         tracing::debug!("Settings::Read");
 

--- a/client/src/backend/usb.rs
+++ b/client/src/backend/usb.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{HandleToken, request::Response, usb::UsbDevice},
@@ -53,6 +55,7 @@ pub(crate) struct UsbInterface {
     imp: Arc<dyn UsbImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl UsbInterface {
@@ -60,8 +63,14 @@ impl UsbInterface {
         imp: Arc<dyn UsbImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -81,12 +90,17 @@ impl UsbInterface {
         app_id: Optional<MaybeAppID>,
         devices: Vec<(String, UsbDevice, AccessOptions)>,
         options: AcquireDevicesOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<Response<Vec<(String, AccessOptions)>>> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Usb::AcquireDevices",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),

--- a/client/src/backend/wallpaper.rs
+++ b/client/src/backend/wallpaper.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use zbus::message::Header;
 
 use crate::{
     MaybeAppID, Uri, WindowIdentifierType,
     backend::{
         Result,
+        caller::CallerAuthorization,
         request::{Request, RequestImpl},
     },
     desktop::{HandleToken, request::ResponseType, wallpaper::WallpaperOptions},
@@ -29,6 +31,7 @@ pub(crate) struct WallpaperInterface {
     imp: Arc<dyn WallpaperImpl>,
     spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
     cnx: zbus::Connection,
+    caller_authorization: Arc<CallerAuthorization>,
 }
 
 impl WallpaperInterface {
@@ -36,8 +39,14 @@ impl WallpaperInterface {
         imp: Arc<dyn WallpaperImpl>,
         cnx: zbus::Connection,
         spawn: Arc<dyn futures_util::task::Spawn + Send + Sync>,
+        caller_authorization: Arc<CallerAuthorization>,
     ) -> Self {
-        Self { imp, cnx, spawn }
+        Self {
+            imp,
+            cnx,
+            spawn,
+            caller_authorization,
+        }
     }
 }
 
@@ -57,12 +66,17 @@ impl WallpaperInterface {
         window_identifier: Optional<WindowIdentifierType>,
         uri: Uri,
         options: WallpaperOptions,
+        #[zbus(header)] header: Header<'_>,
     ) -> Result<ResponseType> {
+        self.caller_authorization
+            .authorize(&self.cnx, &header)
+            .await?;
         let imp = Arc::clone(&self.imp);
 
         Request::spawn(
             "Wallpaper::SetWallpaperURI",
             &self.cnx,
+            Arc::clone(&self.caller_authorization),
             handle.clone(),
             Arc::clone(&self.imp),
             Arc::clone(&self.spawn),


### PR DESCRIPTION
## Summary

- add a reusable `CallerAuthorization` policy for backend D-Bus interfaces
- require the current owner of `org.freedesktop.portal.Desktop` for frontend-facing portal methods by default
- carry the policy into backend `Request::Close` and `Session::Close` objects
- authorize Lockdown property access with a separately configurable policy that inherits the frontend policy by default
- give PermissionStore a separately configurable policy that allows all callers by default because the document portal and PipeWire permission manager are legitimate non-Desktop callers

## Motivation

Backend methods trust frontend-supplied application IDs, handles, and options. Without authenticating the frontend, another process on the session bus can call implementation interfaces directly, spoof an application ID, manipulate an in-flight request, or close a session.

Most implementation calls originate from `org.freedesktop.portal.Desktop`, but Lockdown is intended for multiple portal frontends and PermissionStore has additional service callers. The policy is therefore shared while those two interfaces remain independently configurable.

## Testing

Run in ashpd's CI container with Rust 1.92.0:

- `cargo test --workspace --locked --features gtk4,pipewire,wayland,raw_handle,tracing,backend,frontend`
- `cargo clippy --workspace --features gtk4,pipewire,wayland,raw_handle,tracing,backend,frontend -- -D warnings`
- `cargo check --workspace --locked --features gtk4,pipewire,wayland,raw_handle,tracing,backend,frontend`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p ashpd --all-features --no-deps`
- feature-minimal checks for `async-io,backend` and `tokio,backend,documents`
